### PR TITLE
fix: real /health endpoint, repo hygiene, docs truth pass

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,10 +3,6 @@
 # Necessary API Keys
 # -------------------
 
-# Hugging Face API Key
-# Sign up at https://huggingface.co/join to get your API key.
-# HUGGINGFACE_API_KEY=""
-
 # DeepL API Key
 # Sign up at https://www.deepl.com/en/pro#developer to get your API key.
 DEEPL_API_KEY=your_deepl_api_key
@@ -15,6 +11,10 @@ DEEPL_API_KEY=your_deepl_api_key
 # Sing up and get your API key at https://resend.com/api-keys
 # When RUNNING_LOCALLY is set to False, this key is used to send emails.
 RESEND_API_KEY=your_resend_api_key
+
+# Email address that receives contact form submissions.
+# Required when RUNNING_LOCALLY is set to False.
+CONTACT_EMAIL=you@example.com
 
 # Running Locally (True/False) flag
 # Set this to False if you want to enable the email sending feature for the contact form.

--- a/.gitignore
+++ b/.gitignore
@@ -8,11 +8,19 @@ __pycache__/
 # VS Code specific
 .vscode/
 
-# Output directory
-# output/ 
+# Output directory (generated transcriptions, downloads, logs)
+output/
 
-# Everything inside the output directory
-# output/*
+# Media and transcript files must never be committed
+*.mp3
+*.mp4
+*.m4a
+*.wav
+*.webm
+*.srt
+*.vtt
+*.sbv
+*.zip
 
 # Environments
 .env

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,13 @@
+# Maintenance plan (July 2026)
+
+Codebase audit → fixes landed as a stack of 5 PRs. Merge in order; each PR's base is the previous branch, so GitHub retargets automatically as they merge.
+
+| # | Branch | Issues addressed |
+|---|--------|-----------------|
+| 1 | `fix/health-hygiene-docs` | Real `/health` endpoint (docker healthcheck was false-passing via the catch-all), catch-all returns 404, contact email + Resend header moved to env/uuid, `.env.example` cleanup (drop unused `HUGGINGFACE_API_KEY`), gitignore media/transcripts, README truth pass (no "simulation"/"monitoring"), modern `TemplateResponse` signature |
+| 2 | `fix/pdf-unicode` | PDF export corrupts non-Latin text (latin-1 + abandoned fpdf 1.7.2) → fpdf2 with bundled Unicode font |
+| 3 | `fix/job-identity-sqlite` | Job-identity race ("latest row" lookups cross-wire concurrent jobs) → explicit job id through subprocess argv; SQLite WAL + per-operation connections; relative subprocess path (runs outside Docker); graceful DeepL line-count mismatch handling; dead conda block removed |
+| 4 | `feat/upload-limits-streaming` | Limits 100MB/10min → 1000MB/15min, uploads streamed to disk (no more double full read into memory), user-facing copy updated (index + FAQ), accepted upload formats widened |
+| 5 | `chore/deps-and-tests` | Dependency refresh — fixes all open Dependabot alerts (torch critical, yt-dlp, python-multipart highs; removes unused transformers/accelerate/srt/webvtt-py entirely), `whisper_large` → large-v3, first pytest suite (converters, clean_filename, job-id flow, `/health`, `/transcribe` validation) |
+
+Verification: pytest suite in PR5, live uvicorn smoke tests per PR, and a full Docker build + end-to-end transcription (upload → status → preview → download, Greek PDF check, real YouTube download with new yt-dlp) on the integrated stack.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   </p>
 </div>
 
-Txtify is a free open-source web application that transcribes and translates audio from YouTube videos or uploaded media files. It now runs on Docker for easier deployment and includes monitoring capabilities. Leveraging the **`stable-ts`** library and the **`whisper`** models, Txtify offers enhanced transcription accuracy and performance.
+Txtify is a free open-source web application that transcribes and translates audio from YouTube videos or uploaded media files. It runs on Docker for easier deployment. Leveraging the **`stable-ts`** library and the **`whisper`** models, Txtify offers enhanced transcription accuracy and performance.
 
 ## Table of Contents
 
@@ -116,13 +116,9 @@ If you want to use the pre-built Docker image available on Docker Hub, follow th
 
 Open your web browser and navigate to `http://localhost:8011` to access Txtify.
 
-### Monitoring
+### Logs
 
-To monitor the application and the transcription processes:
-
-1. Ensure you have completed the installation steps above.
-
-2. You can view the logs of the running Docker container to monitor the application output.
+To follow the application output and the transcription processes, view the logs of the running Docker container:
 
 ```sh
 docker logs -f txtify_container
@@ -130,9 +126,9 @@ docker logs -f txtify_container
 
 > <sub>**Note:** The -f option follows the log output in real-time.</sub>
 
-### Online Simulation Demo
+### Online Demo
 
-To understand how Txtify works, you can use the online simulation demo. Visit [Txtify Website](https://txtify.lkmeta.com/) and follow the instructions to upload your media or enter a YouTube URL for a simulated transcription process.
+To see Txtify in action, visit the [Txtify Website](https://txtify.lkmeta.com/) and upload your media or enter a YouTube URL to transcribe it.
 
 ## Roadmap
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ yt_dlp==2025.3.31
 uvicorn==0.22.0
 python-multipart==0.0.18
 accelerate==0.21.0 
-stable-ts==2.18.0
+stable-ts==2.19.1

--- a/src/main.py
+++ b/src/main.py
@@ -7,6 +7,7 @@
 
 import os
 import time
+import uuid
 import zipfile
 from pathlib import Path
 from typing import Optional
@@ -43,26 +44,16 @@ app = FastAPI()
 app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 templates = Jinja2Templates(directory=TEMPLATES_DIR)
 
-DEFINED_REQUESTS = [
-    "/",
-    "/transcribe",
-    "/status",
-    "/cancel",
-    "/download",
-    "/preview",
-    "/downloadPreview",
-    "/cleanup",
-    "/faq",
-    "/contact",
-    "/submit_contact",
-]
-
 DB = transcriptionsDB(str(OUTPUT_DIR / "transcriptions.db"))
 
 RUNNING_LOCALLY = os.getenv("RUNNING_LOCALLY", "True").lower() == "true"
 RESEND_API_KEY = os.getenv("RESEND_API_KEY")
-if not RESEND_API_KEY and not RUNNING_LOCALLY:
-    raise ValueError("RESEND_API_KEY is not set")
+CONTACT_EMAIL = os.getenv("CONTACT_EMAIL")
+if not RUNNING_LOCALLY:
+    if not RESEND_API_KEY:
+        raise ValueError("RESEND_API_KEY is not set")
+    if not CONTACT_EMAIL:
+        raise ValueError("CONTACT_EMAIL is not set")
 
 if not RUNNING_LOCALLY:
     resend.api_key = RESEND_API_KEY
@@ -73,11 +64,15 @@ async def read_form(request: Request):
     """
     Render the transcription form.
     """
-    if request.url.path not in DEFINED_REQUESTS:
-        return templates.TemplateResponse("error.html", {"request": request})
+    return templates.TemplateResponse(request, "index.html")
 
-    context = {"request": request}
-    return templates.TemplateResponse("index.html", context)
+
+@app.get("/health", response_class=JSONResponse)
+async def health():
+    """
+    Health check used by the docker-compose healthcheck.
+    """
+    return {"status": "ok"}
 
 
 @app.get("/faq", response_class=HTMLResponse)
@@ -85,8 +80,7 @@ async def faq(request: Request):
     """
     Render the FAQ page.
     """
-    context = {"request": request}
-    return templates.TemplateResponse("faq.html", context)
+    return templates.TemplateResponse(request, "faq.html")
 
 
 @app.get("/contact", response_class=HTMLResponse)
@@ -94,8 +88,7 @@ async def contact(request: Request):
     """
     Render the contact page.
     """
-    context = {"request": request}
-    return templates.TemplateResponse("contact.html", context)
+    return templates.TemplateResponse(request, "contact.html")
 
 
 @app.post("/submit_contact")
@@ -148,10 +141,10 @@ async def submit_contact(
     try:
         params = resend.Emails.SendParams(
             from_="Txtify <onboarding@resend.dev>",
-            to=["louiskmeta@gmail.com"],
+            to=[CONTACT_EMAIL],
             subject="Txtify Contact Form Submission",
             html=html_content,
-            headers={"X-Entity-Ref-ID": "123456789"},
+            headers={"X-Entity-Ref-ID": str(uuid.uuid4())},
         )
         resend.Emails.send(params)
         logger.info("Email sent successfully!")
@@ -417,11 +410,9 @@ async def cleanup(pid: int):
     )
 
 
-@app.get("/{request}", response_class=HTMLResponse)
-async def catch_all(request: Request):
+@app.get("/{path}", response_class=HTMLResponse)
+async def catch_all(request: Request, path: str):
     """
     Handle non-defined routes.
     """
-    if request.url.path not in DEFINED_REQUESTS:
-        return templates.TemplateResponse("error.html", {"request": request})
-    return templates.TemplateResponse("index.html", {"request": request})
+    return templates.TemplateResponse(request, "error.html", status_code=404)


### PR DESCRIPTION
## Problem
- `docker-compose.yml` healthchecks `/health`, but no such route exists — the request fell into the catch-all `GET /{request}` which returned `error.html` with **HTTP 200**, so the healthcheck always passed, even when it was hitting an error page.
- The catch-all returned 200 for every unknown path.
- `main.py` hard-coded the contact-form recipient (`louiskmeta@gmail.com`) and a static `X-Entity-Ref-ID: 123456789` Resend header.
- `.env.example` documented an unused `HUGGINGFACE_API_KEY`.
- README described the live demo as a "simulation" and claimed "monitoring capabilities" (it's real transcription; monitoring is container logs).
- `output/test` placeholder was tracked; media/transcripts weren't gitignored.
- Template rendering used the legacy `TemplateResponse(name, {"request": ...})` signature, removed in current starlette.

## Change
- Real `GET /health` returning `{"status": "ok"}`.
- Catch-all renders `error.html` with status 404; dead `DEFINED_REQUESTS` list removed (FastAPI matches declared routes before the catch-all).
- Contact recipient comes from new `CONTACT_EMAIL` env var (validated at startup when `RUNNING_LOCALLY=False`); `X-Entity-Ref-ID` is a per-email `uuid4` — a static value defeats the header's duplicate-detection purpose, so uuid was chosen over an env var.
- `.env.example`: dropped HF key, documented `CONTACT_EMAIL`.
- `.gitignore`: `output/`, `*.mp3/mp4/m4a/wav/webm/srt/vtt/sbv/zip`; untracked `output/test`.
- README truth pass; modern `TemplateResponse(request, name)` calls.
- `PLAN.md`: the full 5-PR plan for this maintenance pass (this is PR 1/5).

## How it was verified
Booted with uvicorn and hit every touched route:
```
== /health => 200        {"status":"ok"}
== / => 200
== /faq => 200
== /contact => 200
== /nonexistent => 404
POST /submit_contact => 200 (local mode message)
```

## Deferred
- `old_files/` and `output/transcriptions.db` from the audit were already untracked locally (gitignored) — nothing to remove from git history.
- Full Docker E2E happens once on the integrated stack (see PLAN.md).