### PR TITLE
fix: job-identity race between concurrent transcriptions + SQLite hardening

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -1,6 +1,9 @@
 """
 Database management class for transcription records. It provides methods for
 creating a table, inserting records, updating statuses, and deleting entries.
+
+Each record is identified by its rowid (the job id), created at insert time.
+The OS pid of the worker subprocess is stored alongside it for cancellation.
 """
 
 import sqlite3
@@ -9,47 +12,45 @@ import sqlite3
 class transcriptionsDB:
     """
     A class to manage database operations for transcription records.
+
+    Connections are opened per operation (the app accesses the database from
+    async handlers and separate worker subprocesses), with WAL enabled so
+    readers and writers do not block each other.
     """
 
     def __init__(self, db_path: str):
         """
-        Initialize the database connection.
+        Initialize the database and create the table if needed.
 
         Args:
             db_path (str): The path to the database file.
         """
-        self.db_path = db_path
-        self.conn = sqlite3.connect(db_path, timeout=5)
-        self.cursor = self.conn.cursor()
-        self.create_table()
-
-    def create_table(self) -> None:
-        """
-        Create the transcriptions table if it does not already exist.
-
-        Returns:
-            None
-        """
-        self.cursor.execute(
-            """
-            CREATE TABLE IF NOT EXISTS transcriptions (
-                id INTEGER PRIMARY KEY,
-                youtube_url TEXT,
-                media_path TEXT,
-                language TEXT,
-                model TEXT,
-                translation TEXT,
-                language_translation TEXT,
-                file_export TEXT,
-                status TEXT,
-                created_at TEXT,
-                completed_at TEXT,
-                progress INTEGER,
-                pid INTEGER
+        self.db_path = str(db_path)
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS transcriptions (
+                    id INTEGER PRIMARY KEY,
+                    youtube_url TEXT,
+                    media_path TEXT,
+                    language TEXT,
+                    model TEXT,
+                    translation TEXT,
+                    language_translation TEXT,
+                    file_export TEXT,
+                    status TEXT,
+                    created_at TEXT,
+                    completed_at TEXT,
+                    progress INTEGER,
+                    pid INTEGER
+                )
+                """
             )
-            """
-        )
-        self.conn.commit()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path, timeout=30)
+        conn.execute("PRAGMA journal_mode=WAL")
+        return conn
 
     def insert_transcription(
         self,
@@ -62,12 +63,9 @@ class transcriptionsDB:
         file_export: str,
         status: str,
         created_at: str,
-        completed_at: str,
-        progress: int,
-        pid: int,
-    ) -> None:
+    ) -> int:
         """
-        Insert a new transcription record into the database.
+        Insert a new transcription record and return its job id.
 
         Args:
             youtube_url (str): The URL of the YouTube video.
@@ -79,158 +77,110 @@ class transcriptionsDB:
             file_export (str): The file export format.
             status (str): The current status of the transcription.
             created_at (str): The creation timestamp.
-            completed_at (str): The completion timestamp.
-            progress (int): The transcription progress (0-100).
-            pid (int): The process ID.
 
         Returns:
-            None
+            int: The job id of the new record.
         """
-        self.cursor.execute(
-            """
-            INSERT INTO transcriptions (
-                youtube_url,
-                media_path,
-                language,
-                model,
-                translation,
-                language_translation,
-                file_export,
-                status,
-                created_at,
-                completed_at,
-                progress,
-                pid
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                youtube_url,
-                media_path,
-                language,
-                model,
-                translation,
-                language_translation,
-                file_export,
-                status,
-                created_at,
-                completed_at,
-                progress,
-                pid,
-            ),
-        )
-        self.conn.commit()
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                INSERT INTO transcriptions (
+                    youtube_url, media_path, language, model, translation,
+                    language_translation, file_export, status, created_at,
+                    completed_at, progress, pid
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, '', 0, 0)
+                """,
+                (
+                    youtube_url,
+                    media_path,
+                    language,
+                    model,
+                    translation,
+                    language_translation,
+                    file_export,
+                    status,
+                    created_at,
+                ),
+            )
+            return cursor.lastrowid
 
-    def get_transcription_by_pid(self, pid: int):
+    def get_transcription(self, job_id: int):
         """
-        Retrieve a transcription record by its PID.
+        Retrieve a transcription record by its job id.
 
         Args:
-            pid (int): The process ID.
+            job_id (int): The job id.
 
         Returns:
             tuple or None: The corresponding transcription record, or None if not found.
         """
-        self.cursor.execute(
-            """
-            SELECT * FROM transcriptions WHERE pid=?
-            """,
-            (pid,),
-        )
-        return self.cursor.fetchone()
+        with self._connect() as conn:
+            return conn.execute(
+                "SELECT * FROM transcriptions WHERE id=?", (job_id,)
+            ).fetchone()
 
-    def update_transcription_status_by_pid(
-        self, status: str, completed_at: str, progress: int, pid: int
+    def update_transcription_status(
+        self, status: str, completed_at: str, progress: int, job_id: int
     ) -> None:
         """
-        Update the status, completion timestamp, and progress of a transcription record by PID.
+        Update the status, completion timestamp, and progress of a record.
 
         Args:
             status (str): The new status.
             completed_at (str): The completion timestamp.
             progress (int): The transcription progress (0-100).
-            pid (int): The process ID.
+            job_id (int): The job id.
 
         Returns:
             None
         """
-        self.cursor.execute(
-            """
-            UPDATE transcriptions
-            SET status=?, completed_at=?, progress=?
-            WHERE pid=?
-            """,
-            (status, completed_at, progress, pid),
-        )
-        self.conn.commit()
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE transcriptions SET status=?, completed_at=?, progress=? WHERE id=?",
+                (status, completed_at, progress, job_id),
+            )
 
-    def update_transcription_pid(self, status: str, pid: int) -> None:
+    def set_process_pid(self, pid: int, job_id: int) -> None:
         """
-        Update the status and set the PID for the most recently inserted transcription record.
+        Store the OS pid of the worker subprocess for a job.
 
         Args:
-            status (str): The new status.
-            pid (int): The process ID.
+            pid (int): The OS process ID.
+            job_id (int): The job id.
 
         Returns:
             None
         """
-        self.cursor.execute(
-            """
-            UPDATE transcriptions
-            SET status=?, pid=?
-            WHERE id=(SELECT MAX(id) FROM transcriptions)
-            """,
-            (status, pid),
-        )
-        self.conn.commit()
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE transcriptions SET pid=? WHERE id=?", (pid, job_id)
+            )
 
-    def delete_transcription(self, pid: int) -> None:
+    def get_process_pid(self, job_id: int):
         """
-        Delete a transcription record by PID.
+        Retrieve the OS pid of the worker subprocess for a job.
 
         Args:
-            pid (int): The process ID.
+            job_id (int): The job id.
 
         Returns:
-            None
+            int or None: The OS pid, or None if the job does not exist.
         """
-        self.cursor.execute(
-            """
-            DELETE FROM transcriptions WHERE pid=?
-            """,
-            (pid,),
-        )
-        self.conn.commit()
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT pid FROM transcriptions WHERE id=?", (job_id,)
+            ).fetchone()
+            return row[0] if row else None
 
-    def get_last_process_id(self) -> int:
+    def delete_transcription(self, job_id: int) -> None:
         """
-        Retrieve the most recently inserted process ID.
-
-        Returns:
-            int: The last inserted process ID.
-        """
-        self.cursor.execute(
-            """
-            SELECT pid FROM transcriptions ORDER BY id DESC LIMIT 1
-            """
-        )
-        result = self.cursor.fetchone()
-        return result[0] if result else 0
-
-    def delete_transcription_by_pid(self, pid: int) -> None:
-        """
-        Delete a transcription record by PID.
+        Delete a transcription record by job id.
 
         Args:
-            pid (int): The process ID.
+            job_id (int): The job id.
 
         Returns:
             None
         """
-        self.cursor.execute(
-            """
-            DELETE FROM transcriptions WHERE pid=?
-            """,
-            (pid,),
-        )
-        self.conn.commit()
+        with self._connect() as conn:
+            conn.execute("DELETE FROM transcriptions WHERE id=?", (job_id,))

--- a/src/main.py
+++ b/src/main.py
@@ -307,8 +307,8 @@ async def download(pid: Optional[int] = None):
             status_code=400, detail="PID is required and must be an integer."
         )
 
-    pid_progress = DB.get_transcription_by_pid(pid)[11]
-    if pid_progress < 100:
+    status_data = DB.get_transcription(pid)
+    if not status_data or status_data[11] < 100:
         return JSONResponse(
             content={"message": "Transcription in progress or not found."},
             status_code=404,
@@ -346,8 +346,8 @@ async def downloadPreview(pid: int, format: str):
     if format not in ["txt", "srt", "vtt", "sbv"]:
         return JSONResponse(content={"message": "Invalid file format"}, status_code=400)
 
-    pid_progress = DB.get_transcription_by_pid(pid)[11]
-    if pid_progress < 100:
+    status_data = DB.get_transcription(pid)
+    if not status_data or status_data[11] < 100:
         return JSONResponse(
             content={"message": "Transcription in progress or not found."},
             status_code=404,

--- a/src/main.py
+++ b/src/main.py
@@ -184,7 +184,7 @@ async def transcribe(
                 content={"message": "Invalid file type"}, status_code=400
             )
 
-    DB.insert_transcription(
+    job_id = DB.insert_transcription(
         youtube_url,
         media.filename if media else "",
         language,
@@ -194,12 +194,10 @@ async def transcribe(
         file_export,
         "Processing request...",
         str(time.time()),
-        "",
-        0,
-        0,
     )
 
-    pid = handle_transcription(
+    started = handle_transcription(
+        job_id,
         youtube_url,
         media,
         language,
@@ -209,15 +207,17 @@ async def transcribe(
         file_export,
     )
 
-    if pid:
-        DB.update_transcription_status_by_pid("Processing request...", "", 10, pid)
-    else:
+    if not started:
+        DB.update_transcription_status("Error", str(time.time()), 0, job_id)
         return JSONResponse(
             content={"message": "Failed to start transcription process"},
             status_code=500,
         )
 
-    return {"message": "Transcription started successfully.", "pid": pid}
+    DB.update_transcription_status("Processing request...", "", 10, job_id)
+
+    # The frontend treats this value as an opaque token; it is the job id.
+    return {"message": "Transcription started successfully.", "pid": job_id}
 
 
 @app.get("/status", response_class=JSONResponse)
@@ -230,9 +230,9 @@ async def status(pid: Optional[int] = None):
             status_code=400, detail="PID is required and must be an integer."
         )
 
-    logger.info(f"Getting status for process ID: {pid}")
+    logger.info(f"Getting status for job: {pid}")
 
-    status_data = DB.get_transcription_by_pid(pid)
+    status_data = DB.get_transcription(pid)
     if not status_data:
         return JSONResponse(
             content={"message": "Transcription not found"}, status_code=404
@@ -248,14 +248,14 @@ async def status(pid: Optional[int] = None):
                 if status_data[9]
                 else "In Progress"
             )
-            done = kill_process_by_pid(pid)
+            done = kill_process_by_pid(status_data[12])
 
             logs_file = OUTPUT_DIR / f"{pid}_logs.txt"
             if logs_file.exists():
                 logs_file.rename(OUTPUT_DIR / f"{pid}" / "logs.txt")
 
             if done:
-                logger.info(f"Transcription process {pid} is done!")
+                logger.info(f"Transcription job {pid} is done!")
         except ValueError:
             time_taken = "Invalid data"
 
@@ -279,13 +279,13 @@ async def cancel_transcription(pid: Optional[int] = None):
             status_code=400, detail="PID is required and must be an integer."
         )
 
-    status_data = DB.get_transcription_by_pid(pid)
+    status_data = DB.get_transcription(pid)
     if not status_data:
         return JSONResponse(
             content={"message": "Transcription not found"}, status_code=404
         )
 
-    cancel = kill_process_by_pid(pid)
+    cancel = kill_process_by_pid(status_data[12])
     cleanup_files(pid)
 
     if not cancel:
@@ -293,7 +293,7 @@ async def cancel_transcription(pid: Optional[int] = None):
             content={"message": "Failed to cancel transcription"}, status_code=500
         )
 
-    DB.update_transcription_status_by_pid("Canceled", str(time.time()), 0, pid)
+    DB.update_transcription_status("Canceled", str(time.time()), 0, pid)
     return {"message": "Transcription canceled successfully!"}
 
 

--- a/src/models.py
+++ b/src/models.py
@@ -58,7 +58,7 @@ def transcribe_audio(
     model: str,
     translation: str,
     language_translation: str,
-    pid: int,
+    job_id: int,
 ) -> None:
     """
     Transcribe an audio file using stable-whisper. Optionally translate the
@@ -70,7 +70,7 @@ def transcribe_audio(
         model (str): Model key from the MODELS dictionary.
         translation (str): Translation model or 'none' to skip translation.
         language_translation (str): Target language for translation.
-        pid (int): Process ID for tracking in the database.
+        job_id (int): Database job id for tracking.
 
     Returns:
         None
@@ -83,8 +83,8 @@ def transcribe_audio(
 
     if not file_path:
         logger.error("No file path provided. Progress: 0%")
-        DB.update_transcription_status_by_pid(
-            "Error: No file path provided.", "", 0, pid
+        DB.update_transcription_status(
+            "Error: No file path provided.", "", 0, job_id
         )
         return
 
@@ -95,15 +95,15 @@ def transcribe_audio(
 
     try:
         logger.info("Loading stable-whisper model... Progress: 30%")
-        DB.update_transcription_status_by_pid(
-            "Loading transcription model...", "", 30, pid
+        DB.update_transcription_status(
+            "Loading transcription model...", "", 30, job_id
         )
 
         stable_model_name = STABLE_MODELS.get(MODELS.get(model, DEFAULT_MODEL), "base")
         model_instance = load_model(stable_model_name, device=device, cpu_preload=True)
 
         logger.info("Transcribing... Progress: 40%")
-        DB.update_transcription_status_by_pid("Transcribing...", "", 40, pid)
+        DB.update_transcription_status("Transcribing...", "", 40, job_id)
 
         result = model_instance.transcribe(
             file_path,
@@ -114,7 +114,7 @@ def transcribe_audio(
             suppress_silence=True,
         )
 
-        pid_dir = OUTPUT_DIR / str(pid)
+        pid_dir = OUTPUT_DIR / str(job_id)
         pid_dir.mkdir(parents=True, exist_ok=True)
         srt_file = pid_dir / "en_transcription.srt"
 
@@ -123,9 +123,9 @@ def transcribe_audio(
         result.to_txt(str(pid_dir / "transcription.txt"))
 
         logger.info("Saving transcription... Progress: 70%")
-        DB.update_transcription_status_by_pid("Saving transcription...", "", 70, pid)
+        DB.update_transcription_status("Saving transcription...", "", 70, job_id)
 
-        logger.error("saved transcription on: ", str(pid_dir / "transcription.txt"))
+        logger.info(f"Saved transcription to: {pid_dir / 'transcription.txt'}")
         with open(pid_dir / "transcription.txt", "r", encoding="utf-8") as f:
             transcription = f.read()
 
@@ -133,7 +133,7 @@ def transcribe_audio(
         if translation and language.lower() != language_translation.lower():
             if translation.lower() != "none":
                 logger.info("Translating... Progress: 85%")
-                DB.update_transcription_status_by_pid("Translating...", "", 85, pid)
+                DB.update_transcription_status("Translating...", "", 85, job_id)
                 logger.info(f"Translating from {language} to {language_translation}")
                 source_lang = SOURCE_LANGUAGES.get(language.upper())
                 target_lang = TARGET_LANGUAGES.get(language_translation.upper())
@@ -142,7 +142,7 @@ def transcribe_audio(
                         f"Invalid language code: {language} or {language_translation}"
                     )
                 transcription = deepl_translate(
-                    transcription, language, language_translation, pid
+                    transcription, language, language_translation, job_id
                 )
             else:
                 logger.info("Skipping translation (translation='none').")
@@ -156,20 +156,20 @@ def transcribe_audio(
         )
 
         logger.info("Exporting transcription... Progress: 90%")
-        DB.update_transcription_status_by_pid("Exporting transcription...", "", 90, pid)
+        DB.update_transcription_status("Exporting transcription...", "", 90, job_id)
         convert_to_formats(transcription, str(translated_text_file), "all")
 
         logger.info("Completed successfully! Progress: 100%")
-        DB.update_transcription_status_by_pid(
-            "Completed successfully!", str(time.time()), 100, pid
+        DB.update_transcription_status(
+            "Completed successfully!", str(time.time()), 100, job_id
         )
 
     except Exception as e:
         logger.error(f"Transcription failed: {str(e)}. Progress: 0%")
-        DB.update_transcription_status_by_pid("Error", "", 0, pid)
+        DB.update_transcription_status("Error", "", 0, job_id)
 
 
-def deepl_translate(text: str, source_lang: str, target_lang: str, pid: int) -> str:
+def deepl_translate(text: str, source_lang: str, target_lang: str, job_id: int) -> str:
     """
     Translate text using DeepL, updating progress status if errors occur.
 
@@ -177,7 +177,7 @@ def deepl_translate(text: str, source_lang: str, target_lang: str, pid: int) -> 
         text (str): Original text to translate.
         source_lang (str): Source language code.
         target_lang (str): Target language code.
-        pid (int): Process ID for tracking.
+        job_id (int): Database job id for tracking.
 
     Returns:
         str: Translated text, or the original text on failure.
@@ -197,7 +197,7 @@ def deepl_translate(text: str, source_lang: str, target_lang: str, pid: int) -> 
         return result.text
     except Exception as e:
         logger.error(f"Translation failed: {str(e)}. Progress: 0%")
-        DB.update_transcription_status_by_pid("Translation Error", "", 0, pid)
+        DB.update_transcription_status("Translation Error", "", 0, job_id)
         return text
 
 
@@ -227,9 +227,20 @@ def save_final_transcription(
         if match:
             timestamps.append((match.group(1), match.group(2)))
 
-    translated_lines = translated_text.split("\n")
+    translated_lines = [line for line in translated_text.split("\n") if line.strip()]
     if len(translated_lines) != len(timestamps):
-        raise ValueError("Mismatch between timestamps and translated lines.")
+        # DeepL sometimes merges or splits lines. Align what matches, merge any
+        # extra lines into the last block, and pad missing ones instead of
+        # failing the whole job.
+        logger.warning(
+            f"Timestamp/translation count mismatch: {len(timestamps)} timestamps "
+            f"vs {len(translated_lines)} lines. Aligning best-effort."
+        )
+        if len(translated_lines) > len(timestamps):
+            extra = " ".join(translated_lines[len(timestamps) - 1 :])
+            translated_lines = translated_lines[: len(timestamps) - 1] + [extra]
+        else:
+            translated_lines += [""] * (len(timestamps) - len(translated_lines))
 
     final_blocks = []
     for idx, (start, end) in enumerate(timestamps):

--- a/src/transcribe_process.py
+++ b/src/transcribe_process.py
@@ -1,6 +1,6 @@
 """
-This script handles the transcription process for a single audio file using the 
-`transcribe_audio` function from the models module. It logs progress to a file 
+This script handles the transcription process for a single audio file using the
+`transcribe_audio` function from the models module. It logs progress to a file
 and updates the transcription database accordingly.
 """
 
@@ -9,37 +9,29 @@ from pathlib import Path
 
 from loguru import logger
 
-from db import transcriptionsDB
 from models import transcribe_audio
 
 BASE_DIR = Path(__file__).resolve().parent
 OUTPUT_DIR = BASE_DIR.parent / "output"
 OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
-DB = transcriptionsDB(OUTPUT_DIR / "transcriptions.db")
-
 if __name__ == "__main__":
     """
     Main entry point for transcription.
     Usage:
-        python transcribe_process.py <file_path> <language> <model> <translation> <language_translation> <file_export>
+        python transcribe_process.py <job_id> <file_path> <language> <model> <translation> <language_translation> <file_export>
     """
-    file_path = sys.argv[1]
-    language = sys.argv[2]
-    model = sys.argv[3]
-    translation = sys.argv[4]
-    language_translation = sys.argv[5]
-    file_export = sys.argv[6]
+    job_id = int(sys.argv[1])
+    file_path = sys.argv[2]
+    language = sys.argv[3]
+    model = sys.argv[4]
+    translation = sys.argv[5]
+    language_translation = sys.argv[6]
+    file_export = sys.argv[7]
 
-    process_id = DB.get_last_process_id()
-    if process_id is None:
-        process_id = 0
-
-    print(f"Process ID: {process_id}")
-    logger.info(f"Process ID: {process_id}")
-
-    logs_file = OUTPUT_DIR / f"{process_id}_logs.txt"
+    logs_file = OUTPUT_DIR / f"{job_id}_logs.txt"
     logger.info(
+        f"Job ID: {job_id}\n"
         f"Transcribing audio file: {file_path}\n"
         f"Language: {language}\n"
         f"Model: {model}"
@@ -58,5 +50,5 @@ if __name__ == "__main__":
             model=model,
             translation=translation,
             language_translation=language_translation,
-            pid=process_id,
+            job_id=job_id,
         )

--- a/src/utils.py
+++ b/src/utils.py
@@ -5,12 +5,11 @@ PDF, SRT, VTT, and SBV. It also includes helper functions for cleaning filenames
 validating YouTube URLs, and managing file cleanup.
 """
 
-import os
 import re
 import shutil
 import subprocess
+import sys
 from pathlib import Path
-from typing import Optional
 
 import psutil
 import yt_dlp
@@ -19,22 +18,6 @@ from loguru import logger
 from pydub import AudioSegment
 
 from db import transcriptionsDB
-
-cwd = "/app/src" if os.getenv("RUNNING_IN_DOCKER") else os.getcwd()
-
-# Global dictionary to store transcription status
-transcription_status = {
-    "progress": 0,
-    "phase": "Initializing...",
-    "model": "",
-    "language": "",
-    "translation": "",
-    "time_taken": 0,
-    "completed": False,
-    "file_path": None,
-    "canceled": False,
-    "pid": None,
-}
 
 BASE_DIR = Path(__file__).resolve().parent
 OUTPUT_DIR = BASE_DIR.parent / "output"
@@ -75,6 +58,7 @@ def is_valid_media_file(filename: str) -> bool:
 
 
 def handle_transcription(
+    job_id: int,
     youtube_url: str,
     media,
     language: str,
@@ -82,12 +66,13 @@ def handle_transcription(
     translation: str,
     language_translation: str,
     file_export: str,
-) -> Optional[int]:
+) -> bool:
     """
     Handle the transcription process: download YouTube or handle uploaded media,
     then launch a separate transcription subprocess.
 
     Args:
+        job_id (int): Database job id created when the request was inserted.
         youtube_url (str): The YouTube video URL.
         media: Uploaded media file.
         language (str): Transcription language.
@@ -97,7 +82,7 @@ def handle_transcription(
         file_export (str): Export format.
 
     Returns:
-        Optional[int]: The PID of the subprocess, or None on failure.
+        bool: True if the subprocess was launched, False on failure.
     """
     output_file = None
     try:
@@ -146,38 +131,11 @@ def handle_transcription(
 
         logger.info(f"Transcription started for: {output_file}")
 
-        # Local process
-        # conda_env = "txtify"
-        # process = subprocess.Popen(
-        #     [
-        #         "conda",
-        #         "run",
-        #         "--name",
-        #         conda_env,
-        #         "python",
-        #         "transcribe_process.py",
-        #         str(output_file),
-        #         language,
-        #         model,
-        #         translation,
-        #         language_translation,
-        #         file_export,
-        #     ],
-        #     stdout=subprocess.PIPE,
-        #     stderr=subprocess.PIPE,
-        #     cwd=cwd + "/src",
-        # )
-        # logger.warning(f"Running subprocess in directory: {cwd} + '/src'")
-
-        # stdout, stderr = process.communicate()
-        # logger.warning(f"STDOUT: {stdout.decode()}")
-        # logger.warning(f"STDERR: {stderr.decode()}")
-
-        # # Docker container process
         process = subprocess.Popen(
             [
-                "python",
-                "/app/src/transcribe_process.py",
+                sys.executable,
+                str(BASE_DIR / "transcribe_process.py"),
+                str(job_id),
                 str(output_file),
                 language,
                 model,
@@ -188,39 +146,20 @@ def handle_transcription(
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
-            # cwd="/app/src",
         )
 
-        # logger.warning(f"Running subprocess in directory: /app/src'")
+        DB.set_process_pid(process.pid, job_id)
+        logger.info(f"Transcription job {job_id} started with PID: {process.pid}")
 
-        # stdout_data, stderr_data = process.communicate()
-        # logger.warning(f"STDOUT: {stdout_data}")
-        # logger.warning(f"STDERR: {stderr_data}")
-
-        pid = process.pid
-        if pid:
-            DB.update_transcription_pid("Processing request...", pid)
-            transcription_status["phase"] = "Processing request..."
-            transcription_status["progress"] = 10
-            transcription_status["pid"] = pid
-            logger.info(f"Transcription process started with PID: {pid}")
-        else:
-            raise Exception("Failed to start transcription process")
-
-        pid_output_dir = OUTPUT_DIR / f"{pid}"
-
-        # Check if pid_output_dir exists and if yes clean it
-        if pid_output_dir.exists():
-            shutil.rmtree(pid_output_dir)
-
-        pid_output_dir.mkdir(parents=True, exist_ok=True)
-        return pid
+        job_output_dir = OUTPUT_DIR / str(job_id)
+        if job_output_dir.exists():
+            shutil.rmtree(job_output_dir)
+        job_output_dir.mkdir(parents=True, exist_ok=True)
+        return True
 
     except Exception as e:
-        transcription_status["phase"] = "Error"
-        transcription_status["progress"] = 0
         logger.error(f"Transcription failed: {str(e)}")
-        return None
+        return False
 
 
 def convert_to_mp3(file_path: Path) -> Path:


### PR DESCRIPTION
PR 3/5 — stacked on #14.

## Problem
1. **Job-identity race.** `transcribe_process.py` located its DB row with `get_last_process_id()` ("latest row"), and `handle_transcription` attached the OS pid to the max-id row. Two overlapping jobs cross-wired: job A's subprocess would update job B's row, statuses/downloads mixed up.
2. **SQLite misuse.** One module-level connection shared across async handlers, plus separate connections in each worker subprocess, default journal mode, 5s timeout — a recipe for `database is locked`.
3. `/app/src/transcribe_process.py` was hard-coded, so the app only worked inside Docker; a 50-line dead conda block sat next to it.
4. `save_final_transcription` raised `ValueError` whenever DeepL merged/split lines vs the SRT segment count — killing an otherwise-finished job at the last step.

## Change
- Explicit **job id** created at INSERT (`cursor.lastrowid`), passed through subprocess argv, used for all status updates, output dirs, and log files. OS pid stored only for kill/cancel. "Latest row" helpers deleted. The frontend keeps working unchanged — it already treats the `pid` field as an opaque token, which is now the job id.
- `db.py`: per-operation connections, `PRAGMA journal_mode=WAL`, 30s timeout.
- Worker spawned with `sys.executable` + path relative to `src/`; runs outside Docker.
- Translation alignment degrades gracefully: extra lines merge into the last block, missing lines pad empty, with a warning log.
- Removed dead conda block, unused `transcription_status` global, and a `logger.error` misuse.

## How it was verified
Two concurrent `POST /transcribe` requests against a live uvicorn:
```
{"message":"Transcription started successfully.","pid":1}
{"message":"Transcription started successfully.","pid":2}
/status?pid=1 → {"progress":"10",...,"model":"whisper_base","language":"el"}
/status?pid=2 → {"progress":"10",...,"model":"whisper_tiny","language":"en"}
/status?pid=99 → 404
DB: 1|el|whisper_base|...|42319   2|en|whisper_tiny|...|42320
```
Each job keeps its own row (distinct OS pids stored per row). Alignment edge cases (exact / merged / split DeepL output) exercised directly: `alignment OK`.

## Deferred
DB rows are tuples with index access in `main.py` (pre-existing); switching to `sqlite3.Row` would be a nice follow-up but touches every consumer.