### PR TITLE
feat: 1000MB/15min limits with streamed uploads

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -23,6 +23,7 @@ from loguru import logger
 
 from db import transcriptionsDB
 from utils import (
+    MAX_UPLOAD_SIZE_MB,
     cleanup_files,
     handle_transcription,
     is_valid_media_file,
@@ -182,6 +183,13 @@ async def transcribe(
         if not is_valid_media_file(media.filename):
             return JSONResponse(
                 content={"message": "Invalid file type"}, status_code=400
+            )
+        if media.size and media.size > MAX_UPLOAD_SIZE_MB * 1024 * 1024:
+            return JSONResponse(
+                content={
+                    "message": f"Uploaded file exceeds {MAX_UPLOAD_SIZE_MB} MB limit."
+                },
+                status_code=400,
             )
 
     job_id = DB.insert_transcription(

--- a/src/utils.py
+++ b/src/utils.py
@@ -25,8 +25,10 @@ OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
 DB = transcriptionsDB(OUTPUT_DIR / "transcriptions.db")
 
-MAX_VIDEO_DURATION = 10 * 60  # 10 minutes in seconds
-MAX_UPLOAD_SIZE_MB = 100  # 100 MB limit
+# User-facing limits. Keep the copy in templates/index.html and
+# templates/faq.html in sync when changing these.
+MAX_VIDEO_DURATION = 15 * 60  # YouTube audio is truncated at 15 minutes
+MAX_UPLOAD_SIZE_MB = 1000  # uploaded files are rejected above 1000 MB
 
 
 def is_valid_youtube_url(url: str) -> bool:
@@ -53,7 +55,9 @@ def is_valid_media_file(filename: str) -> bool:
     Returns:
         bool: True if supported, False otherwise.
     """
-    valid_extensions = ["mp4", "mp3"]
+    # Anything ffmpeg/pydub can decode; keep in sync with the accept list
+    # in templates/index.html.
+    valid_extensions = ["mp3", "mp4", "m4a", "wav", "webm", "ogg", "flac", "aac", "mov"]
     return filename.split(".")[-1].lower() in valid_extensions
 
 
@@ -118,15 +122,23 @@ def handle_transcription(
             logger.info(f"Downloaded video: {output_file}")
 
         elif media:
-            media_size_mb = len(media.file.read()) / (1024 * 1024)
-            media.file.seek(0)
-            if media_size_mb > MAX_UPLOAD_SIZE_MB:
-                raise Exception(f"Uploaded file exceeds {MAX_UPLOAD_SIZE_MB} MB limit.")
-
             media_filename = clean_filename(media.filename)
             media_file_path = OUTPUT_DIR / media_filename
-            with open(media_file_path, "wb") as buffer:
-                buffer.write(media.file.read())
+            max_bytes = MAX_UPLOAD_SIZE_MB * 1024 * 1024
+            written = 0
+            try:
+                # Stream to disk in chunks; never hold the whole upload in memory.
+                with open(media_file_path, "wb") as buffer:
+                    while chunk := media.file.read(1024 * 1024):
+                        written += len(chunk)
+                        if written > max_bytes:
+                            raise Exception(
+                                f"Uploaded file exceeds {MAX_UPLOAD_SIZE_MB} MB limit."
+                            )
+                        buffer.write(chunk)
+            except Exception:
+                media_file_path.unlink(missing_ok=True)
+                raise
             output_file = convert_to_mp3(media_file_path)
 
         logger.info(f"Transcription started for: {output_file}")

--- a/templates/faq.html
+++ b/templates/faq.html
@@ -166,8 +166,8 @@
 
             <h2>Limitations</h2>
             <h3>Are there any limitations?</h3>
-            <p>Yes, this version has limitations. You can upload files up to 100MB or transcribe YouTube videos up
-                to 10 minutes. However, when you self-host Txtify, you can modify and run the application without these
+            <p>Yes, this version has limitations. You can upload files up to 1000MB or transcribe YouTube videos up
+                to 15 minutes. However, when you self-host Txtify, you can modify and run the application without these
                 limitations, giving you full control over the transcription process.</p>
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -62,9 +62,9 @@
             languages. Export in multiple formats including 
             <span id="file-types" style="color: var(--primary-color); font-weight: bold;"></span>.
             Txtify supports files up to 
-            <span style="color: var(--primary-color); font-weight: bold;">100MB</span> 
+            <span style="color: var(--primary-color); font-weight: bold;">1000MB</span> 
             and YouTube videos up to 
-            <span style="color: var(--primary-color); font-weight: bold;">10 minutes</span>.
+            <span style="color: var(--primary-color); font-weight: bold;">15 minutes</span>.
             <br><br>
             Please note that this website is a 
             <span style="color: var(--primary-color); font-weight: bold;">demo version</span> 
@@ -84,8 +84,8 @@
             languages.
             Export in multiple formats including <span id="file-types"
                 style="color: var(--primary-color); font-weight: bold;"></span>.
-            Txtify supports files up to <span style="color: var(--primary-color); font-weight: bold;">100MB</span>
-            and YouTube videos up to <span style="color: var(--primary-color); font-weight: bold;">10 minutes</span>.
+            Txtify supports files up to <span style="color: var(--primary-color); font-weight: bold;">1000MB</span>
+            and YouTube videos up to <span style="color: var(--primary-color); font-weight: bold;">15 minutes</span>.
             <br><br>
             Please note that this website is a <span style="color: var(--primary-color); font-weight: bold;">demo
                 version</span> intended to showcase the functionality of Txtify. To utilize the full features of Txtify,
@@ -101,13 +101,13 @@
         </div>
         <div id="youtube-input" class="input-group">
             <label for="youtube-url">YouTube URL:</label>
-            <small>Enter the URL of the YouTube video you want to transcribe (max 10 minutes trascription).</small>
+            <small>Enter the URL of the YouTube video you want to transcribe (max 15 minutes of transcription).</small>
             <input type="text" id="youtube-url" placeholder="Enter YouTube URL">
         </div>
         <div id="upload-input" class="input-group" style="display: none;">
             <label for="media-upload">Upload Audio/Video:</label>
-            <small>Upload an audio or video file from your device to transcribe (.mp4, .mp3 -- max 100MB).</small>
-            <input type="file" id="media-upload" accept=".mp4,.mp3">
+            <small>Upload an audio or video file from your device to transcribe (.mp3, .mp4, .m4a, .wav, .webm and more -- max 1000MB).</small>
+            <input type="file" id="media-upload" accept=".mp3,.mp4,.m4a,.wav,.webm,.ogg,.flac,.aac,.mov">
         </div>
 
         <div class="input-group">


### PR DESCRIPTION
PR 4/5 — stacked on #15.

## Problem
- Limits were 100MB / 10 minutes in code and copy; the intended limits are 1000MB / 15 minutes (there was an uncommitted local edit to this effect with stale comments).
- `handle_transcription` read the entire upload into memory **twice** (`media.file.read()` to measure size, then again to write) — unacceptable at 1GB.
- `is_valid_media_file` accepted only mp3/mp4 even though the pipeline (ffmpeg/pydub) happily converts much more, and models.py already special-cases m4a.

## Change
- `MAX_VIDEO_DURATION = 15 * 60`, `MAX_UPLOAD_SIZE_MB = 1000`, with comments that now match the values and a pointer to keep template copy in sync.
- Uploads stream to disk in 1MB chunks; the limit is enforced mid-stream and a partial file is removed on failure. `/transcribe` also fast-rejects with 400 when `media.size` already exceeds the limit.
- Copy updated in `templates/index.html` (hero, upload hint incl. 'trascription' typo, `accept` attribute) and `templates/faq.html`.
- Accepted extensions: mp3, mp4, m4a, wav, webm, ogg, flac, aac, mov.

## How it was verified
Unit-level (limit shrunk to 1MB for the test):
```
stream guard OK      # over-limit upload → rejected mid-stream, no partial file left
extensions OK        # .wav/.M4A accepted, .exe rejected
```
Live uvicorn:
```
POST /transcribe (x.exe)   → 400
POST /transcribe (tone.mp3) → {"message":"Transcription started successfully.","pid":3}
```

## Deferred
No duration probe for uploaded files (the 15-min cap applies to YouTube, where yt-dlp truncates the audio; uploads are bounded by size). Probing local duration via ffprobe is easy to add if wanted.