### PR TITLE
fix: memory, subtitle corruption, worker liveness, and file-isolation defects

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,12 +14,16 @@ jobs:
         with:
           python-version: "3.10"
           cache: pip
+      - name: Install ffmpeg
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq ffmpeg
       - name: Install dependencies (without the ML stack)
         run: |
           pip install --upgrade pip
           # tests stub torch/stable_whisper (see tests/conftest.py); skip the
-          # multi-GB ML wheels so CI stays fast
+          # multi-GB ML wheels so CI stays fast. Test-tool pins match
+          # requirements-dev.txt.
           grep -v -E '^(torch|stable-ts)' requirements.txt > /tmp/reqs.txt
-          pip install -r /tmp/reqs.txt pytest httpx pypdf
+          grep -v '^-r' requirements-dev.txt >> /tmp/reqs.txt
+          pip install -r /tmp/reqs.txt
       - name: Run tests
         run: pytest -v

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ fpdf2==2.8.3
 jinja2==3.1.6
 loguru==0.7.3
 psutil==7.2.2
-pydub==0.25.1
 python-dotenv==1.2.2
 python-multipart==0.0.32
 resend==2.33.0

--- a/src/db.py
+++ b/src/db.py
@@ -7,6 +7,7 @@ The OS pid of the worker subprocess is stored alongside it for cancellation.
 """
 
 import sqlite3
+from contextlib import closing
 
 
 class transcriptionsDB:
@@ -26,7 +27,7 @@ class transcriptionsDB:
             db_path (str): The path to the database file.
         """
         self.db_path = str(db_path)
-        with self._connect() as conn:
+        with closing(self._connect()) as conn, conn:
             conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS transcriptions (
@@ -81,7 +82,7 @@ class transcriptionsDB:
         Returns:
             int: The job id of the new record.
         """
-        with self._connect() as conn:
+        with closing(self._connect()) as conn, conn:
             cursor = conn.execute(
                 """
                 INSERT INTO transcriptions (
@@ -114,7 +115,7 @@ class transcriptionsDB:
         Returns:
             tuple or None: The corresponding transcription record, or None if not found.
         """
-        with self._connect() as conn:
+        with closing(self._connect()) as conn, conn:
             return conn.execute(
                 "SELECT * FROM transcriptions WHERE id=?", (job_id,)
             ).fetchone()
@@ -134,7 +135,7 @@ class transcriptionsDB:
         Returns:
             None
         """
-        with self._connect() as conn:
+        with closing(self._connect()) as conn, conn:
             conn.execute(
                 "UPDATE transcriptions SET status=?, completed_at=?, progress=? WHERE id=?",
                 (status, completed_at, progress, job_id),
@@ -151,7 +152,7 @@ class transcriptionsDB:
         Returns:
             None
         """
-        with self._connect() as conn:
+        with closing(self._connect()) as conn, conn:
             conn.execute(
                 "UPDATE transcriptions SET pid=? WHERE id=?", (pid, job_id)
             )
@@ -166,7 +167,7 @@ class transcriptionsDB:
         Returns:
             int or None: The OS pid, or None if the job does not exist.
         """
-        with self._connect() as conn:
+        with closing(self._connect()) as conn, conn:
             row = conn.execute(
                 "SELECT pid FROM transcriptions WHERE id=?", (job_id,)
             ).fetchone()
@@ -182,5 +183,5 @@ class transcriptionsDB:
         Returns:
             None
         """
-        with self._connect() as conn:
+        with closing(self._connect()) as conn, conn:
             conn.execute("DELETE FROM transcriptions WHERE id=?", (job_id,))

--- a/src/main.py
+++ b/src/main.py
@@ -257,7 +257,8 @@ async def status(pid: Optional[int] = None):
         # A worker that died without a terminal DB write (e.g. import crash)
         # would otherwise leave the frontend polling forever.
         worker_pid = status_data[12]
-        if worker_pid and not is_worker_alive(worker_pid) and "Error" not in status_data[8]:
+        already_terminal = "Error" in status_data[8] or status_data[8] == "Canceled"
+        if worker_pid and not already_terminal and not is_worker_alive(worker_pid):
             logger.error(f"Worker for job {pid} died without finishing")
             DB.update_transcription_status("Error", str(time.time()), 0, pid)
             return {

--- a/src/main.py
+++ b/src/main.py
@@ -15,6 +15,7 @@ from typing import Optional
 import resend
 from dotenv import load_dotenv
 from fastapi import FastAPI, File, Form, Request, UploadFile
+from fastapi.concurrency import run_in_threadpool
 from fastapi.exceptions import HTTPException
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
@@ -28,6 +29,7 @@ from utils import (
     handle_transcription,
     is_valid_media_file,
     is_valid_youtube_url,
+    is_worker_alive,
     kill_process_by_pid,
 )
 
@@ -204,7 +206,12 @@ async def transcribe(
         str(time.time()),
     )
 
-    started = handle_transcription(
+    DB.update_transcription_status("Processing request...", "", 10, job_id)
+
+    # Download/convert can take minutes for large media; run off the event
+    # loop so other requests (status polls) keep being served.
+    started = await run_in_threadpool(
+        handle_transcription,
         job_id,
         youtube_url,
         media,
@@ -221,8 +228,6 @@ async def transcribe(
             content={"message": "Failed to start transcription process"},
             status_code=500,
         )
-
-    DB.update_transcription_status("Processing request...", "", 10, job_id)
 
     # The frontend treats this value as an opaque token; it is the job id.
     return {"message": "Transcription started successfully.", "pid": job_id}
@@ -249,6 +254,20 @@ async def status(pid: Optional[int] = None):
     logger.info(f"Transcription status: {status_data}")
     if status_data[11] < 100:
         time_taken = "In Progress"
+        # A worker that died without a terminal DB write (e.g. import crash)
+        # would otherwise leave the frontend polling forever.
+        worker_pid = status_data[12]
+        if worker_pid and not is_worker_alive(worker_pid) and "Error" not in status_data[8]:
+            logger.error(f"Worker for job {pid} died without finishing")
+            DB.update_transcription_status("Error", str(time.time()), 0, pid)
+            return {
+                "progress": "0",
+                "phase": "Error",
+                "model": status_data[4],
+                "language": status_data[3],
+                "translation": status_data[5],
+                "time_taken": "In Progress",
+            }
     else:
         try:
             time_taken = (

--- a/src/models.py
+++ b/src/models.py
@@ -213,7 +213,7 @@ def save_final_transcription(
         output_file_path (str): Output file path for the merged result.
 
     Returns:
-        str: The fully merged transcription as a single string.
+        list[str]: The merged transcription as numbered SRT blocks.
     """
     with open(srt_file_path, "r", encoding="utf-8") as srt_file:
         srt_content = srt_file.readlines()
@@ -240,7 +240,10 @@ def save_final_transcription(
             extra = " ".join(translated_lines[len(timestamps) - 1 :])
             translated_lines = translated_lines[: len(timestamps) - 1] + [extra]
         else:
-            translated_lines += [""] * (len(timestamps) - len(translated_lines))
+            # Pad with a visible placeholder, never "": the srt/vtt/sbv
+            # converters drop empty lines, which would mispair every
+            # (timestamp, text) couple after the pad point.
+            translated_lines += ["..."] * (len(timestamps) - len(translated_lines))
 
     final_blocks = []
     for idx, (start, end) in enumerate(timestamps):

--- a/src/transcribe_process.py
+++ b/src/transcribe_process.py
@@ -1,23 +1,18 @@
 """
-This script handles the transcription process for a single audio file using the
-`transcribe_audio` function from the models module. It logs progress to a file
-and updates the transcription database accordingly.
+Worker entrypoint: transcribes a single audio file via `transcribe_audio` and
+updates the transcription database. Spawned by handle_transcription with
+stdout/stderr redirected to output/<job_id>_logs.txt, so everything printed
+or logged here (including import-time crashes) lands in the job log.
 """
 
 import sys
-from pathlib import Path
 
 from loguru import logger
 
 from models import transcribe_audio
 
-BASE_DIR = Path(__file__).resolve().parent
-OUTPUT_DIR = BASE_DIR.parent / "output"
-OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-
 if __name__ == "__main__":
     """
-    Main entry point for transcription.
     Usage:
         python transcribe_process.py <job_id> <file_path> <language> <model> <translation> <language_translation> <file_export>
     """
@@ -29,7 +24,6 @@ if __name__ == "__main__":
     language_translation = sys.argv[6]
     file_export = sys.argv[7]
 
-    logs_file = OUTPUT_DIR / f"{job_id}_logs.txt"
     logger.info(
         f"Job ID: {job_id}\n"
         f"Transcribing audio file: {file_path}\n"
@@ -37,18 +31,11 @@ if __name__ == "__main__":
         f"Model: {model}"
     )
 
-    with logs_file.open("w") as log:
-        # Redirect stdout and stderr to the log file
-        sys.stdout = log
-        sys.stderr = log
-        logger.add(log)
-        logger.info("Created log file.")
-
-        transcribe_audio(
-            file_path=file_path,
-            language=language,
-            model=model,
-            translation=translation,
-            language_translation=language_translation,
-            job_id=job_id,
-        )
+    transcribe_audio(
+        file_path=file_path,
+        language=language,
+        model=model,
+        translation=translation,
+        language_translation=language_translation,
+        job_id=job_id,
+    )

--- a/src/utils.py
+++ b/src/utils.py
@@ -15,7 +15,6 @@ import psutil
 import yt_dlp
 from fpdf import FPDF
 from loguru import logger
-from pydub import AudioSegment
 
 from db import transcriptionsDB
 
@@ -55,7 +54,7 @@ def is_valid_media_file(filename: str) -> bool:
     Returns:
         bool: True if supported, False otherwise.
     """
-    # Anything ffmpeg/pydub can decode; keep in sync with the accept list
+    # Anything ffmpeg can decode; keep in sync with the accept list
     # in templates/index.html.
     valid_extensions = ["mp3", "mp4", "m4a", "wav", "webm", "ogg", "flac", "aac", "mov"]
     return filename.split(".")[-1].lower() in valid_extensions
@@ -108,7 +107,10 @@ def handle_transcription(
                 sanitized_title = clean_filename(info_dict["title"])
                 info_dict["title"] = sanitized_title
 
-            ydl_opts["outtmpl"] = str(OUTPUT_DIR / f"{sanitized_title}.%(ext)s")
+            # Prefix with the job id so concurrent jobs never share files.
+            ydl_opts["outtmpl"] = str(
+                OUTPUT_DIR / f"{job_id}_{sanitized_title}.%(ext)s"
+            )
 
             with yt_dlp.YoutubeDL(ydl_opts) as ydl:
                 ydl.download([youtube_url])
@@ -122,8 +124,9 @@ def handle_transcription(
             logger.info(f"Downloaded video: {output_file}")
 
         elif media:
+            # Prefix with the job id so concurrent jobs never share files.
             media_filename = clean_filename(media.filename)
-            media_file_path = OUTPUT_DIR / media_filename
+            media_file_path = OUTPUT_DIR / f"{job_id}_{media_filename}"
             max_bytes = MAX_UPLOAD_SIZE_MB * 1024 * 1024
             written = 0
             try:
@@ -143,6 +146,9 @@ def handle_transcription(
 
         logger.info(f"Transcription started for: {output_file}")
 
+        # Worker output goes straight to the job log file: a PIPE that nobody
+        # reads loses import-time crashes and blocks the worker once full.
+        worker_log = open(OUTPUT_DIR / f"{job_id}_logs.txt", "a")
         process = subprocess.Popen(
             [
                 sys.executable,
@@ -155,10 +161,11 @@ def handle_transcription(
                 language_translation,
                 file_export,
             ],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stdout=worker_log,
+            stderr=subprocess.STDOUT,
             text=True,
         )
+        worker_log.close()
 
         DB.set_process_pid(process.pid, job_id)
         logger.info(f"Transcription job {job_id} started with PID: {process.pid}")
@@ -186,9 +193,24 @@ def convert_to_mp3(file_path: Path) -> Path:
     """
     file_extension = file_path.suffix.lower()
     if file_extension != ".mp3":
-        audio = AudioSegment.from_file(file_path)
         mp3_file_path = file_path.with_suffix(".mp3")
-        audio.export(mp3_file_path, format="mp3")
+        # ffmpeg streams the conversion; decoding via pydub loaded the whole
+        # file into RAM as raw PCM (multiple GB for a 1000MB upload).
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-i",
+                str(file_path),
+                "-codec:a",
+                "libmp3lame",
+                str(mp3_file_path),
+            ],
+            check=True,
+        )
         file_path.unlink()
         logger.info(f"File converted to MP3: {mp3_file_path}")
         return mp3_file_path
@@ -208,6 +230,23 @@ def clean_filename(filename: str) -> str:
     filename = re.sub(r"[^a-zA-Z0-9_.-]", "_", filename)
     filename = re.sub(r"__+", "_", filename)
     return filename
+
+
+def is_worker_alive(pid: int) -> bool:
+    """
+    True if the worker process is still running. Exited workers linger as
+    zombies (the server never wait()s on them), so zombie == dead.
+
+    Args:
+        pid (int): The OS process ID.
+
+    Returns:
+        bool: True if running, False if exited or never existed.
+    """
+    try:
+        return psutil.Process(pid).status() != psutil.STATUS_ZOMBIE
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        return False
 
 
 def kill_process_by_pid(pid: int) -> bool:
@@ -459,14 +498,14 @@ def cleanup_files(pid: int) -> None:
     Returns:
         None
     """
-    pid_directory = OUTPUT_DIR / str(pid)
-    if pid_directory.exists():
-        shutil.rmtree(pid_directory)
+    job_directory = OUTPUT_DIR / str(pid)
+    if job_directory.exists():
+        shutil.rmtree(job_directory)
 
-        for file in OUTPUT_DIR.iterdir():
-            if file.suffix in [".mp3", ".zip"]:
-                file.unlink()
+    # Only this job's artifacts — deleting every *.mp3/*.zip used to destroy
+    # concurrently running jobs' inputs.
+    for file in OUTPUT_DIR.glob(f"{pid}_*"):
+        file.unlink(missing_ok=True)
+    (OUTPUT_DIR / f"{pid}.zip").unlink(missing_ok=True)
 
-        logger.info(f"Files cleaned up for PID: {pid}")
-    else:
-        logger.warning(f"No files found to clean up for PID: {pid}")
+    logger.info(f"Files cleaned up for job: {pid}")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -19,8 +19,9 @@ def test_unknown_route_is_404(client):
 
 
 def test_transcribe_invalid_youtube_url(client):
-    r = client.post("/transcribe", data=_form(), files={})
-    r = client.post("/transcribe", data={**_form(), "youtube_url": "http://not-youtube.com/x"})
+    r = client.post(
+        "/transcribe", data={**_form(), "youtube_url": "http://not-youtube.com/x"}
+    )
     assert r.status_code == 400
     assert "Invalid YouTube URL" in r.json()["message"]
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -35,6 +35,21 @@ def test_deepl_merged_lines_pads(tmp_path):
     assert len(blocks) == 3
 
 
+def test_padded_blocks_keep_srt_converter_aligned(tmp_path):
+    """Padding must survive the srt/vtt/sbv converters: an empty pad line
+    would be dropped by their filters and mispair every following block."""
+    from utils import convert_to_srt
+
+    blocks = run(tmp_path, "a\nb")  # one line short -> last block padded
+    out = tmp_path / "padded.srt"
+    convert_to_srt("\n".join(blocks), out)
+    content = out.read_text(encoding="utf-8")
+    assert "Invalid timestamp" not in content
+    assert "00:00:00,000 --> 00:00:02,000\na" in content
+    assert "00:00:02,000 --> 00:00:04,000\nb" in content
+    assert "00:00:04,000 --> 00:00:06,000\n..." in content
+
+
 def test_deepl_split_lines_merges_extras(tmp_path):
     """Extra translated lines fold into the last block instead of raising."""
     blocks = run(tmp_path, "a\nb\nc\nd\ne")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -72,6 +72,44 @@ def test_convert_to_sbv(tmp_path):
     assert "00:00:02.000,00:00:04.500\nΓειά σου κόσμε" in content
 
 
+def test_cleanup_files_only_touches_own_job(tmp_path, monkeypatch):
+    monkeypatch.setattr(utils, "OUTPUT_DIR", tmp_path)
+    (tmp_path / "1").mkdir()
+    (tmp_path / "1_audio.mp3").touch()
+    (tmp_path / "1_logs.txt").touch()
+    (tmp_path / "1.zip").touch()
+    (tmp_path / "2_other.mp3").touch()  # concurrent job's input
+    (tmp_path / "2.zip").touch()
+    (tmp_path / "12_other.mp3").touch()  # id prefix must not glob-collide
+
+    utils.cleanup_files(1)
+
+    assert not (tmp_path / "1").exists()
+    assert not (tmp_path / "1_audio.mp3").exists()
+    assert not (tmp_path / "1_logs.txt").exists()
+    assert not (tmp_path / "1.zip").exists()
+    assert (tmp_path / "2_other.mp3").exists()
+    assert (tmp_path / "2.zip").exists()
+    assert (tmp_path / "12_other.mp3").exists()
+
+
+def test_convert_to_mp3_streams_via_ffmpeg(tmp_path):
+    import shutil as _shutil
+    import subprocess as _subprocess
+
+    if not _shutil.which("ffmpeg"):
+        pytest.skip("ffmpeg not installed")
+    wav = tmp_path / "clip.wav"
+    _subprocess.run(
+        ["ffmpeg", "-hide_banner", "-loglevel", "error", "-y", "-f", "lavfi",
+         "-i", "sine=frequency=440:duration=1", str(wav)],
+        check=True,
+    )
+    mp3 = utils.convert_to_mp3(wav)
+    assert mp3.suffix == ".mp3" and mp3.stat().st_size > 0
+    assert not wav.exists()
+
+
 def test_convert_to_pdf_preserves_unicode(tmp_path):
     pypdf = pytest.importorskip("pypdf")
     out = tmp_path / "t.pdf"


### PR DESCRIPTION
## Problem
An adversarial review (via the new `txtify-reviewer` agent) of the merged job-flow work confirmed five defects, two of them user-visible:

1. **Multi-GB RAM spike + frozen event loop**: `convert_to_mp3` decoded the whole upload into RAM (pydub → raw PCM), synchronously inside the async handler — at the new 1000MB limit that's several GB and every other request stalls for the duration.
2. **Silently corrupted subtitles**: DeepL line-count mismatches were padded with `""`, which the srt/vtt/sbv converters drop — mispairing every (timestamp, text) pair after the pad point in files the user downloads from a job marked *Completed successfully*.
3. **Invisible worker deaths**: worker stdout/stderr went to a never-read PIPE, so import-time crashes vanished and jobs hung at 10% forever; a full pipe could also block a running worker.
4. **File-level cross-wiring**: uploads keyed by bare filename (two concurrent `audio.mp3` uploads collide) and cancel/cleanup deleted **every** `*.mp3`/`*.zip` in output/, killing other running jobs.
5. Progress written to 10 after the worker already ran (transient backwards progress).

## Change
ffmpeg-subprocess streaming conversion (pydub removed from requirements); `run_in_threadpool` for the blocking download/convert; visible `...` placeholder padding + converter-level regression test; worker output redirected to the job log and `/status` flips dead-worker jobs (zombie == dead) to Error; job-id-prefixed media files + job-scoped cleanup with a glob-collision test (`1_*` vs `12_*`); ordering fix; sqlite connections explicitly closed; CI test deps pinned and ffmpeg installed for the new conversion test.

## How it was verified
```
35 passed, 1 warning in 0.79s
PASS: docker E2E complete        # full build → transcribe → download gate
```
Dead-worker path exercised live (worker without torch crashes at import): job log captures the traceback and /status returns `{"progress":"0","phase":"Error",...}` instead of hanging at 10 — reproduced before the fix, confirmed after.

## Deferred
- `deepl_translate` failure writes a transient Error/0 status then continues with untranslated text (review finding 6, low).
- `.gitignore` doesn't mirror every media pattern `.dockerignore` has; local personal files are excluded via `.git/info/exclude`.