### PR TITLE
fix: cancel kills the worker, terminal states stick, orphaned jobs recover

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -50,6 +50,7 @@ class transcriptionsDB:
 
     def _connect(self) -> sqlite3.Connection:
         conn = sqlite3.connect(self.db_path, timeout=30)
+        conn.row_factory = sqlite3.Row
         conn.execute("PRAGMA journal_mode=WAL")
         return conn
 
@@ -136,8 +137,13 @@ class transcriptionsDB:
             None
         """
         with closing(self._connect()) as conn, conn:
+            # Terminal states (Canceled / any Error) are never overwritten —
+            # e.g. a worker update must not race past a user's cancel.
             conn.execute(
-                "UPDATE transcriptions SET status=?, completed_at=?, progress=? WHERE id=?",
+                """
+                UPDATE transcriptions SET status=?, completed_at=?, progress=?
+                WHERE id=? AND status != 'Canceled' AND status NOT LIKE '%Error%'
+                """,
                 (status, completed_at, progress, job_id),
             )
 
@@ -172,6 +178,24 @@ class transcriptionsDB:
                 "SELECT pid FROM transcriptions WHERE id=?", (job_id,)
             ).fetchone()
             return row[0] if row else None
+
+    def mark_orphans_as_error(self) -> int:
+        """
+        Mark all unfinished jobs as Error. Called at server startup: workers
+        from a previous container run can never complete.
+
+        Returns:
+            int: Number of rows updated.
+        """
+        with closing(self._connect()) as conn, conn:
+            cursor = conn.execute(
+                """
+                UPDATE transcriptions SET status='Error', progress=0
+                WHERE progress < 100 AND status != 'Canceled'
+                      AND status NOT LIKE '%Error%'
+                """
+            )
+            return cursor.rowcount
 
     def delete_transcription(self, job_id: int) -> None:
         """

--- a/src/main.py
+++ b/src/main.py
@@ -49,6 +49,11 @@ templates = Jinja2Templates(directory=TEMPLATES_DIR)
 
 DB = transcriptionsDB(str(OUTPUT_DIR / "transcriptions.db"))
 
+# Workers from a previous container run can never finish their jobs.
+_orphans = DB.mark_orphans_as_error()
+if _orphans:
+    logger.warning(f"Marked {_orphans} unfinished jobs from a previous run as Error")
+
 RUNNING_LOCALLY = os.getenv("RUNNING_LOCALLY", "True").lower() == "true"
 RESEND_API_KEY = os.getenv("RESEND_API_KEY")
 CONTACT_EMAIL = os.getenv("CONTACT_EMAIL")
@@ -252,31 +257,33 @@ async def status(pid: Optional[int] = None):
         )
 
     logger.info(f"Transcription status: {status_data}")
-    if status_data[11] < 100:
+    if status_data["progress"] < 100:
         time_taken = "In Progress"
         # A worker that died without a terminal DB write (e.g. import crash)
         # would otherwise leave the frontend polling forever.
-        worker_pid = status_data[12]
-        already_terminal = "Error" in status_data[8] or status_data[8] == "Canceled"
+        worker_pid = status_data["pid"]
+        already_terminal = (
+            "Error" in status_data["status"] or status_data["status"] == "Canceled"
+        )
         if worker_pid and not already_terminal and not is_worker_alive(worker_pid):
             logger.error(f"Worker for job {pid} died without finishing")
             DB.update_transcription_status("Error", str(time.time()), 0, pid)
             return {
                 "progress": "0",
                 "phase": "Error",
-                "model": status_data[4],
-                "language": status_data[3],
-                "translation": status_data[5],
+                "model": status_data["model"],
+                "language": status_data["language"],
+                "translation": status_data["translation"],
                 "time_taken": "In Progress",
             }
     else:
         try:
             time_taken = (
-                str(round(float(status_data[10]) - float(status_data[9]), 2))
-                if status_data[9]
+                str(round(float(status_data["completed_at"]) - float(status_data["created_at"]), 2))
+                if status_data["created_at"]
                 else "In Progress"
             )
-            done = kill_process_by_pid(status_data[12])
+            done = kill_process_by_pid(status_data["pid"])
 
             logs_file = OUTPUT_DIR / f"{pid}_logs.txt"
             if logs_file.exists():
@@ -288,11 +295,11 @@ async def status(pid: Optional[int] = None):
             time_taken = "Invalid data"
 
     return {
-        "progress": str(status_data[11]),
-        "phase": status_data[8],
-        "model": status_data[4],
-        "language": status_data[3],
-        "translation": status_data[5],
+        "progress": str(status_data["progress"]),
+        "phase": status_data["status"],
+        "model": status_data["model"],
+        "language": status_data["language"],
+        "translation": status_data["translation"],
         "time_taken": time_taken,
     }
 
@@ -313,15 +320,11 @@ async def cancel_transcription(pid: Optional[int] = None):
             content={"message": "Transcription not found"}, status_code=404
         )
 
-    cancel = kill_process_by_pid(status_data[12])
-    cleanup_files(pid)
-
-    if not cancel:
-        return JSONResponse(
-            content={"message": "Failed to cancel transcription"}, status_code=500
-        )
-
+    # Best effort: the worker may already be dead — cancel must still succeed.
+    if not kill_process_by_pid(status_data["pid"]):
+        logger.info(f"No live worker to kill for job {pid}")
     DB.update_transcription_status("Canceled", str(time.time()), 0, pid)
+    cleanup_files(pid)
     return {"message": "Transcription canceled successfully!"}
 
 
@@ -336,7 +339,7 @@ async def download(pid: Optional[int] = None):
         )
 
     status_data = DB.get_transcription(pid)
-    if not status_data or status_data[11] < 100:
+    if not status_data or status_data["progress"] < 100:
         return JSONResponse(
             content={"message": "Transcription in progress or not found."},
             status_code=404,
@@ -375,7 +378,7 @@ async def downloadPreview(pid: int, format: str):
         return JSONResponse(content={"message": "Invalid file format"}, status_code=400)
 
     status_data = DB.get_transcription(pid)
-    if not status_data or status_data[11] < 100:
+    if not status_data or status_data["progress"] < 100:
         return JSONResponse(
             content={"message": "Transcription in progress or not found."},
             status_code=404,

--- a/src/models.py
+++ b/src/models.py
@@ -196,8 +196,10 @@ def deepl_translate(text: str, source_lang: str, target_lang: str, job_id: int) 
         )
         return result.text
     except Exception as e:
-        logger.error(f"Translation failed: {str(e)}. Progress: 0%")
-        DB.update_transcription_status("Translation Error", "", 0, job_id)
+        # Degrade gracefully: keep the original text and let the job finish.
+        # Writing an Error status here would (a) be terminal under the DB's
+        # no-overwrite rule and (b) look like job death to pollers.
+        logger.warning(f"Translation failed, keeping original text: {str(e)}")
         return text
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -232,10 +232,25 @@ def clean_filename(filename: str) -> str:
     return filename
 
 
+def _worker_process(pid: int):
+    """
+    Return the psutil.Process for a *worker* pid, or None. Guards against OS
+    pid reuse: if the pid now belongs to an unrelated process, it is not ours.
+    """
+    try:
+        process = psutil.Process(pid)
+        if any("transcribe_process.py" in part for part in process.cmdline()):
+            return process
+    except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+        pass
+    return None
+
+
 def is_worker_alive(pid: int) -> bool:
     """
     True if the worker process is still running. Exited workers linger as
-    zombies (the server never wait()s on them), so zombie == dead.
+    zombies (the server never wait()s on them), so zombie == dead; a recycled
+    pid belonging to another process also counts as dead.
 
     Args:
         pid (int): The OS process ID.
@@ -243,15 +258,16 @@ def is_worker_alive(pid: int) -> bool:
     Returns:
         bool: True if running, False if exited or never existed.
     """
+    process = _worker_process(pid)
     try:
-        return psutil.Process(pid).status() != psutil.STATUS_ZOMBIE
-    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        return process is not None and process.status() != psutil.STATUS_ZOMBIE
+    except psutil.NoSuchProcess:
         return False
 
 
 def kill_process_by_pid(pid: int) -> bool:
     """
-    Terminate a process by its PID.
+    Terminate a worker process and its children by its PID.
 
     Args:
         pid (int): The process ID.
@@ -259,10 +275,13 @@ def kill_process_by_pid(pid: int) -> bool:
     Returns:
         bool: True if terminated, False otherwise.
     """
+    process = _worker_process(pid)
+    if process is None:
+        return False
     try:
-        process = psutil.Process(pid)
         for proc in process.children(recursive=True):
             proc.kill()
+        process.kill()
         return True
     except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
         return False

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -86,6 +86,56 @@ def test_download_endpoints_404_for_unknown_or_running_jobs(client, monkeypatch)
     assert client.get(f"/downloadPreview?pid={job_id}&format=srt").status_code == 404
 
 
+def test_cancel_succeeds_even_when_worker_already_dead(client, monkeypatch):
+    monkeypatch.setattr(main, "handle_transcription", lambda *a, **k: True)
+    job_id = client.post(
+        "/transcribe",
+        data=_form(),
+        files={"media": ("tone.mp3", io.BytesIO(b"fake-mp3"), "audio/mpeg")},
+    ).json()["pid"]
+
+    r = client.post(f"/cancel?pid={job_id}")
+    assert r.status_code == 200
+
+    status = client.get(f"/status?pid={job_id}").json()
+    assert status["phase"] == "Canceled"
+    # a late worker write must not resurrect the job
+    main.DB.update_transcription_status("Transcribing...", "", 40, job_id)
+    assert client.get(f"/status?pid={job_id}").json()["phase"] == "Canceled"
+
+
+def test_worker_argv_contract(monkeypatch, tmp_path):
+    """handle_transcription's argv order must match transcribe_process.py."""
+    import io as _io
+
+    import utils
+
+    captured = {}
+
+    class FakeProc:
+        pid = 4242
+
+        def __init__(self, args, **kwargs):
+            captured["args"] = args
+
+    monkeypatch.setattr(utils.subprocess, "Popen", FakeProc)
+    monkeypatch.setattr(utils, "OUTPUT_DIR", tmp_path)
+    monkeypatch.setattr(utils.DB, "set_process_pid", lambda *a: None)
+
+    class FakeUpload:
+        filename = "clip.mp3"
+        file = _io.BytesIO(b"x" * 10)
+
+    assert utils.handle_transcription(7, None, FakeUpload(), "en", "whisper_tiny", "none", "EL", "all")
+    args = captured["args"]
+    # transcribe_process.py reads: job_id, file_path, language, model,
+    # translation, language_translation, file_export — in this order.
+    assert args[1].endswith("transcribe_process.py")
+    assert args[2] == "7"
+    assert args[3].endswith("7_clip.mp3")
+    assert args[4:] == ["en", "whisper_tiny", "none", "EL", "all"]
+
+
 def test_transcribe_failure_returns_500(client, monkeypatch):
     monkeypatch.setattr(main, "handle_transcription", lambda *a, **k: False)
     r = client.post(

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -42,6 +42,41 @@ def test_get_missing_job(tmp_path):
     assert db.get_process_pid(42) is None
 
 
+def test_terminal_status_never_overwritten(tmp_path):
+    db = make_db(tmp_path)
+    a = insert(db)
+    db.update_transcription_status("Canceled", "1.0", 0, a)
+    db.update_transcription_status("Transcribing...", "", 40, a)  # late worker write
+    assert db.get_transcription(a)["status"] == "Canceled"
+
+    b = insert(db)
+    db.update_transcription_status("Error", "1.0", 0, b)
+    db.update_transcription_status("Completed successfully!", "2.0", 100, b)
+    assert db.get_transcription(b)["status"] == "Error"
+
+
+def test_mark_orphans_as_error(tmp_path):
+    db = make_db(tmp_path)
+    running = insert(db)
+    done = insert(db)
+    canceled = insert(db)
+    db.update_transcription_status("Transcribing...", "", 40, running)
+    db.update_transcription_status("Completed successfully!", "2.0", 100, done)
+    db.update_transcription_status("Canceled", "1.0", 0, canceled)
+
+    assert db.mark_orphans_as_error() == 1
+    assert db.get_transcription(running)["status"] == "Error"
+    assert db.get_transcription(done)["status"] == "Completed successfully!"
+    assert db.get_transcription(canceled)["status"] == "Canceled"
+
+
+def test_rows_support_named_access(tmp_path):
+    db = make_db(tmp_path)
+    a = insert(db, "el")
+    row = db.get_transcription(a)
+    assert row["language"] == "el" and row["progress"] == 0 and row["id"] == a
+
+
 def test_delete(tmp_path):
     db = make_db(tmp_path)
     a = insert(db)


### PR DESCRIPTION
From the 7-dimension repo evaluation (avg 6.3/10) — the most-confirmed defect cluster. Closes #22.

## Problem
- `kill_process_by_pid` killed only the worker's children, never the worker: **/cancel never actually canceled anything**, and a dead worker's recycled OS pid could be mistaken for a live job (or killed as one).
- A late worker write could resurrect a canceled job; a stale 'Translation Error' status was written mid-job and looked terminal.
- Jobs from a previous container run polled forever after a restart.
- `main.py` addressed DB rows by magic tuple indices.

## Change
Worker-identity guard (cmdline must be `transcribe_process.py`) for both kill and liveness; `process.kill()` added; /cancel is best-effort and always cleans up + marks Canceled; DB refuses to overwrite terminal states; startup marks orphaned jobs Error; DeepL failure keeps original text without fake-terminal status; `sqlite3.Row` named access.

## How it was verified
```
40 passed (5 new: terminal-state guard, orphan sweep, named access, cancel-when-dead, worker argv contract)
PASS: docker E2E complete   (on the integration tree with all sibling PRs merged)
```