### PR TITLE
fix: working healthcheck and correct volumes in the Docker front door

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,5 +31,9 @@ ENV PYTHONPATH=/app/src
 # Expose port 8011
 EXPOSE 8011
 
+# Healthcheck via stdlib — the image does not ship curl
+HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8011/health', timeout=5)" || exit 1
+
 # Run the application
 CMD ["python", "-m", "uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8011"]

--- a/README.md
+++ b/README.md
@@ -101,8 +101,10 @@ If you want to use the pre-built Docker image available on Docker Hub, follow th
    ```
 2. Run the Docker Container
    ```bash
-    docker run -d -p 8011:8011 lkmeta/txtify:latest
+   docker run -d -p 8011:8011 --env-file .env -v ./output:/app/output lkmeta/txtify:latest
    ```
+
+> <sub>`--env-file .env` provides your DeepL API key (translation silently stays disabled without it); `-v ./output:/app/output` keeps transcriptions and job state on your machine across container restarts.</sub>
 
 > **Note:** If you're using Unraid or an AMD architecture, check out the [docker hub images](https://hub.docker.com/repository/docker/lkmeta/txtify/tags). You can pull and run it with:
 >

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   txtify:
     build:
@@ -11,12 +9,11 @@ services:
       - "8011:8011"
     environment:
       - PYTHONUNBUFFERED=1
+    env_file:
+      - .env
     volumes:
-      - .:/app
+      # Persist transcriptions and job state; never mount the whole repo over
+      # /app — that masks the image's code with whatever is on the host.
+      - ./output:/app/output
     restart: unless-stopped
-    healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8011/health" ]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 40s
+    # Healthcheck comes from the image (see Dockerfile HEALTHCHECK).


### PR DESCRIPTION
## Problem
The compose healthcheck ran `curl`, which the image never installs — **every container has been reporting unhealthy forever**. The `.:/app` bind mount masked the built image's code with the host repo (and silently delivered .env). The README's `docker run` quickstart omitted `--env-file`, so Docker Hub users got translation silently disabled, and no output volume.

## Change
HEALTHCHECK moved into the image using stdlib urllib; compose gets `env_file` + an `./output` volume instead of the repo mount; deprecated `version:` key dropped; README quickstart fixed.

## How it was verified
```
docker compose config -q  → ok
docker inspect txtify_hc  → health=healthy   (first time ever)
PASS: docker E2E complete (integration tree)
```