### PR TITLE
test: model/translation/YouTube benchmark with WER baseline

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -1,0 +1,26 @@
+# Benchmark baseline
+
+Regenerate with `./scripts/benchmark.sh` (add `BENCH_YOUTUBE=1` for the YouTube
+leg) and compare against this table before releases. Wall time is submit → 100%
+through the real API inside Docker; **first run per model includes the model
+download** — the `txtify-bench-cache` volume makes later runs inference-only.
+
+## 2026-07-16 — Docker Desktop macOS (arm64), CPU, 7.7GB RAM, 6s speech fixture
+
+| run | wall time | text ok | first transcribed line |
+|-----|-----------|---------|------------------------|
+| whisper_tiny | 30s | yes | the quick brown fox jumps over the lazy dog. |
+| whisper_base | 30s | yes | The quick brown fox jumps over the lazy dog. |
+| whisper_small | 96s | yes | The quick brown fox jumps over the lazy dog. |
+| whisper_medium | 298s | yes | The quick brown fox jumps over the lazy dog. |
+| whisper_large | FAILED | - | out of memory: large-v3 (fp32 on CPU) needs ~10GB+; container had 7.7GB |
+| deepl en→el (base) | 10s | yes | Η γρήγορη καφέ αλεπού πηδάει πάνω από τον τεμπέλη σκύλο. |
+| youtube (tiny) | 8s | yes | Alright so here we are one of the elephant's cool thing |
+
+Notes:
+- Translation verified with a real DeepL API call (EN source → EL target),
+  Greek asserted by character class in the SRT preview.
+- YouTube leg downloads and transcribes a real 19s video inside the container
+  (network-dependent; may hit YouTube bot checks on shared IPs).
+- whisper_large needs more container memory than a default Docker Desktop
+  allocation — raise Docker's memory limit to benchmark it.

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -2,22 +2,30 @@
 
 Regenerate with `./scripts/benchmark.sh` (add `BENCH_YOUTUBE=1` for the YouTube
 leg) and compare against this table before releases. Wall time is submit → 100%
-through the real API inside Docker; **first run per model includes the model
-download** — the `txtify-bench-cache` volume makes later runs inference-only.
+through the real API inside Docker. WER = word error rate vs the fixture's
+reference text (lower is better). The `txtify-bench-cache` volume caches model
+downloads: cold = first ever run per model, warm = subsequent runs
+(inference only).
 
 ## 2026-07-16 — Docker Desktop macOS (arm64), CPU, 7.7GB RAM, 6s speech fixture
 
-| run | wall time | text ok | first transcribed line |
-|-----|-----------|---------|------------------------|
-| whisper_tiny | 30s | yes | the quick brown fox jumps over the lazy dog. |
-| whisper_base | 30s | yes | The quick brown fox jumps over the lazy dog. |
-| whisper_small | 96s | yes | The quick brown fox jumps over the lazy dog. |
-| whisper_medium | 298s | yes | The quick brown fox jumps over the lazy dog. |
-| whisper_large | FAILED | - | out of memory: large-v3 (fp32 on CPU) needs ~10GB+; container had 7.7GB |
-| deepl en→el (base) | 10s | yes | Η γρήγορη καφέ αλεπού πηδάει πάνω από τον τεμπέλη σκύλο. |
-| youtube (tiny) | 8s | yes | Alright so here we are one of the elephant's cool thing |
+| run | cold | warm | text ok | WER | first transcribed line |
+|-----|------|------|---------|-----|------------------------|
+| whisper_tiny | 30s | 5s | yes | 7% | the quick brown fox jumps over the lazy dog. |
+| whisper_base | 30s | 5s | yes | 7% | The quick brown fox jumps over the lazy dog. |
+| whisper_small | 96s | 10s | yes | 7% | The quick brown fox jumps over the lazy dog. |
+| whisper_medium | 298s | 26s | yes | 7% | The quick brown fox jumps over the lazy dog. |
+| whisper_large | OOM | - | - | - | large-v3 (fp32, CPU) needs ~10GB+; container had 7.7GB |
+| deepl en→el (base) | 10s | 10s | yes | - | Η γρήγορη καφέ αλεπού πηδάει πάνω από τον τεμπέλη σκύλο. |
+| youtube (tiny) | 8s | 8s | yes | - | Alright so here we are one of the elephant's cool thing |
 
 Notes:
+- 7% WER = exactly 1 of 15 reference words wrong — the invented brand name
+  "Txtify", which no ASR model knows. All models got every real word right on
+  this clean TTS fixture; treat a jump in WER on the same fixture as a
+  regression signal, not an absolute accuracy claim. (Published Whisper WER on
+  clean English benchmarks: tiny ≈ 7-8%, base ≈ 5%, small ≈ 3.4%,
+  medium ≈ 2.9%, large-v3 ≈ 1.8%.)
 - Translation verified with a real DeepL API call (EN source → EL target),
   Greek asserted by character class in the SRT preview.
 - YouTube leg downloads and transcribes a real 19s video inside the container

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,8 @@ pytest                      # 32+ unit/API tests; runs WITHOUT torch installed
 ./scripts/docker_e2e.sh     # full gate: docker build → boot → real transcription
                             # → preview/download checks. Ends with "PASS: docker E2E complete"
 uvicorn main:app --port 8011   # quick local iteration only (from src/); ffmpeg required
+./scripts/benchmark.sh         # all whisper models + DeepL translation through the real
+                               # API in Docker; compare against BENCHMARK.md baseline
 ```
 
 **The canonical build is always Docker with the pinned `requirements.txt`** (`docker compose up --build` / `scripts/docker_e2e.sh`). Local venvs are for fast iteration and unit tests only — never treat "works locally" as verified; the deployment artifact is the image.
@@ -33,6 +35,14 @@ For quick local work you don't need the ML stack: install `requirements-dev.txt`
 - `transformers`, `accelerate`, `srt`, `webvtt-py` were removed as unused — don't re-add without an actual import.
 - Product name is **Txtify**, never "Textify".
 - Worker failures are invisible in the server log (stdout/stderr piped and unread). Debug via `output/<job id>_logs.txt`, or run `python src/transcribe_process.py <job_id> <file> en whisper_tiny none en all` manually.
+
+## Sibling repo: txtify-web (the public site)
+
+- Located at `../txtify-web` (github.com/lkmeta/txtify-web), deployed on Vercel at txtify.lkmeta.com. It is the **marketing/demo site only**: its transcription flow is fake (demo mode), its contact form emails the owner via Resend. This repo (`txtify`) is the real engine that self-hosters run via Docker.
+- **Division of labor:** engine features, job flow, models, Docker → here. Site copy, SEO, accessibility, site performance, contact form → txtify-web. Don't fix site content here or engine behavior there.
+- **Limits sync contract:** user-facing limits are stated in BOTH repos. Here: `MAX_UPLOAD_SIZE_MB` / `MAX_VIDEO_DURATION` in `src/utils.py` (+ this repo's own templates). In txtify-web: `MAX_FILE_SIZE` / `MAX_YOUTUBE_DURATION` in `src/main.py` (Jinja globals — its single source). If you change limits here, update txtify-web's `src/main.py` too (both currently state 1000MB / 15 minutes — in sync as of July 2026).
+- The site also states: model list (Whisper Tiny→Large, all multilingual), 72 transcription / 34 translation languages (computed from its JSONs), export formats txt/srt/vtt/sbv/pdf. If any of those change here, tell txtify-web (its language JSONs are copies of this repo's).
+- txtify-web has its own CLAUDE.md, smoke-test CI, and a `ui-review` skill — reuse them there rather than rebuilding.
 
 ## Conventions
 

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -21,6 +21,7 @@ IMAGE=txtify:bench
 NAME=txtify_bench
 FIXTURE=tests/fixtures/speech.mp3
 EXPECT="quick brown fox"
+REFERENCE="the quick brown fox jumps over the lazy dog welcome to txtify your transcription assistant"
 if [ "$#" -gt 0 ]; then MODELS=("$@"); else
   MODELS=(whisper_tiny whisper_base whisper_small whisper_medium whisper_large)
 fi
@@ -53,6 +54,25 @@ submit_and_wait() {  # args: extra curl -F options...; sets DUR and SRT
   curl -sf -X POST "$BASE/cleanup?pid=$job" >/dev/null || true
 }
 
+wer() {  # word error rate (%) of SRT $1's text lines vs $REFERENCE
+  python3 - "$REFERENCE" "$1" <<'PY'
+import re, sys
+# keep only subtitle text lines (drop indices and timestamp lines)
+text = " ".join(
+    l for l in sys.argv[2].splitlines()
+    if l.strip() and "-->" not in l and not l.strip().isdigit()
+)
+norm = lambda s: re.sub(r"[^a-z0-9' ]", " ", s.lower()).split()
+ref, hyp = norm(sys.argv[1]), norm(text)
+d = list(range(len(hyp) + 1))
+for i, r in enumerate(ref, 1):
+    prev, d[0] = d[0], i
+    for j, h in enumerate(hyp, 1):
+        prev, d[j] = d[j], min(d[j] + 1, d[j - 1] + 1, prev + (r != h))
+print(f"{100 * d[len(hyp)] / max(1, len(ref)):.0f}%")
+PY
+}
+
 ROWS=""
 for model in "${MODELS[@]}"; do
   echo "==> $model"
@@ -60,10 +80,11 @@ for model in "${MODELS[@]}"; do
        -F translation=none -F language_translation=en; then
     line=$(printf '%s\n' "$SRT" | sed -n 3p)
     if printf '%s' "$SRT" | tr '[:upper:]' '[:lower:]' | /usr/bin/grep -q "$EXPECT"; then ok="yes"; else ok="NO"; fi
-    ROWS="$ROWS| $model | ${DUR}s | $ok | $line |
+    W=$(wer "$SRT")
+    ROWS="$ROWS| $model | ${DUR}s | $ok | $W | $line |
 "
   else
-    ROWS="$ROWS| $model | FAILED | - | - |
+    ROWS="$ROWS| $model | FAILED | - | - | - |
 "
   fi
 done
@@ -74,10 +95,10 @@ if /usr/bin/grep -qE '^DEEPL_API_KEY=..' .env 2>/dev/null; then
        -F translation=deepl -F language_translation=EL; then
     line=$(printf '%s\n' "$SRT" | sed -n 3p)
     if printf '%s' "$SRT" | /usr/bin/grep -q '[α-ωΑ-Ω]'; then ok="yes"; else ok="NO"; fi
-    ROWS="$ROWS| deepl en→el (base) | ${DUR}s | $ok | $line |
+    ROWS="$ROWS| deepl en→el (base) | ${DUR}s | $ok | - | $line |
 "
   else
-    ROWS="$ROWS| deepl en→el (base) | FAILED | - | - |
+    ROWS="$ROWS| deepl en→el (base) | FAILED | - | - | - |
 "
   fi
 else
@@ -89,15 +110,15 @@ if [ "${BENCH_YOUTUBE:-0}" = "1" ]; then
   if submit_and_wait -F "youtube_url=https://www.youtube.com/watch?v=jNQXAC9IVRw" \
        -F language=en -F model=whisper_tiny -F translation=none -F language_translation=en; then
     line=$(printf '%s\n' "$SRT" | sed -n 3p)
-    ROWS="$ROWS| youtube (tiny) | ${DUR}s | yes | $line |
+    ROWS="$ROWS| youtube (tiny) | ${DUR}s | yes | - | $line |
 "
   else
-    ROWS="$ROWS| youtube (tiny) | FAILED | - | - |
+    ROWS="$ROWS| youtube (tiny) | FAILED | - | - | - |
 "
   fi
 fi
 
 echo
-echo "| run | wall time | text ok | first transcribed line |"
-echo "|-----|-----------|---------|------------------------|"
+echo "| run | wall time | text ok | WER | first transcribed line |"
+echo "|-----|-----------|---------|-----|------------------------|"
 printf '%s' "$ROWS"

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Benchmark every Whisper model (and the DeepL translation path) against the
+# real Docker image, using the committed speech fixture. Prints a markdown
+# table; run before releases and compare with BENCHMARK.md.
+#
+# Usage:
+#   ./scripts/benchmark.sh                 # all five models
+#   ./scripts/benchmark.sh whisper_tiny whisper_base
+#   BENCH_YOUTUBE=1 ./scripts/benchmark.sh # also benchmark the YouTube path
+#
+# Notes:
+# - Whisper models are cached in the named docker volume `txtify-bench-cache`,
+#   so the first run per model includes the download; later runs measure
+#   inference only.
+# - The translation row needs DEEPL_API_KEY in .env (skipped otherwise).
+set -uo pipefail
+
+PORT="${BENCH_PORT:-8091}"
+BASE="http://127.0.0.1:${PORT}"
+IMAGE=txtify:bench
+NAME=txtify_bench
+FIXTURE=tests/fixtures/speech.mp3
+EXPECT="quick brown fox"
+if [ "$#" -gt 0 ]; then MODELS=("$@"); else
+  MODELS=(whisper_tiny whisper_base whisper_small whisper_medium whisper_large)
+fi
+trap 'docker rm -f $NAME >/dev/null 2>&1 || true' EXIT
+
+echo "==> Building image"
+docker build -q -t $IMAGE . >/dev/null
+
+echo "==> Starting container (model cache volume: txtify-bench-cache)"
+docker rm -f $NAME >/dev/null 2>&1 || true
+docker run -d --rm --name $NAME -p "${PORT}:8011" \
+  --env-file .env -v txtify-bench-cache:/root/.cache $IMAGE >/dev/null
+for _ in $(seq 1 30); do curl -sf "$BASE/health" >/dev/null && break; sleep 2; done
+
+submit_and_wait() {  # args: extra curl -F options...; sets DUR and SRT
+  local start end job progress
+  start=$(date +%s)
+  job=$(curl -sf -X POST "$BASE/transcribe" "$@" \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)["pid"])') || return 1
+  for _ in $(seq 1 360); do   # up to 30 min (large on CPU is slow)
+    progress=$(curl -sf "$BASE/status?pid=$job" | python3 -c 'import json,sys; print(json.load(sys.stdin)["progress"])' || echo "")
+    [ "$progress" = "100" ] && break
+    [ "$progress" = "0" ] && { echo "    job $job errored:" >&2; docker exec $NAME tail -5 "output/${job}_logs.txt" >&2 || true; return 1; }
+    sleep 5
+  done
+  [ "$progress" = "100" ] || return 1
+  end=$(date +%s)
+  DUR=$((end - start))
+  SRT=$(curl -sf "$BASE/preview?pid=$job" | python3 -c 'import json,sys; print(json.load(sys.stdin)["srt"])')
+  curl -sf -X POST "$BASE/cleanup?pid=$job" >/dev/null || true
+}
+
+ROWS=""
+for model in "${MODELS[@]}"; do
+  echo "==> $model"
+  if submit_and_wait -F media=@"$FIXTURE" -F language=en -F "model=$model" \
+       -F translation=none -F language_translation=en; then
+    line=$(printf '%s\n' "$SRT" | sed -n 3p)
+    if printf '%s' "$SRT" | tr '[:upper:]' '[:lower:]' | /usr/bin/grep -q "$EXPECT"; then ok="yes"; else ok="NO"; fi
+    ROWS="$ROWS| $model | ${DUR}s | $ok | $line |
+"
+  else
+    ROWS="$ROWS| $model | FAILED | - | - |
+"
+  fi
+done
+
+if /usr/bin/grep -qE '^DEEPL_API_KEY=..' .env 2>/dev/null; then
+  echo "==> translation (whisper_base, en -> el via DeepL)"
+  if submit_and_wait -F media=@"$FIXTURE" -F language=en -F model=whisper_base \
+       -F translation=deepl -F language_translation=EL; then
+    line=$(printf '%s\n' "$SRT" | sed -n 3p)
+    if printf '%s' "$SRT" | /usr/bin/grep -q '[α-ωΑ-Ω]'; then ok="yes"; else ok="NO"; fi
+    ROWS="$ROWS| deepl en→el (base) | ${DUR}s | $ok | $line |
+"
+  else
+    ROWS="$ROWS| deepl en→el (base) | FAILED | - | - |
+"
+  fi
+else
+  echo "==> translation skipped (no DEEPL_API_KEY in .env)"
+fi
+
+if [ "${BENCH_YOUTUBE:-0}" = "1" ]; then
+  echo "==> youtube path (whisper_tiny, 19s video)"
+  if submit_and_wait -F "youtube_url=https://www.youtube.com/watch?v=jNQXAC9IVRw" \
+       -F language=en -F model=whisper_tiny -F translation=none -F language_translation=en; then
+    line=$(printf '%s\n' "$SRT" | sed -n 3p)
+    ROWS="$ROWS| youtube (tiny) | ${DUR}s | yes | $line |
+"
+  else
+    ROWS="$ROWS| youtube (tiny) | FAILED | - | - |
+"
+  fi
+fi
+
+echo
+echo "| run | wall time | text ok | first transcribed line |"
+echo "|-----|-----------|---------|------------------------|"
+printf '%s' "$ROWS"


### PR DESCRIPTION
## Problem
No repeatable way to measure that all models, the DeepL translation path, and the YouTube path work — or how accurate/fast they are — before a release.

## Change
`scripts/benchmark.sh`: every whisper model against the committed speech fixture through the real API in Docker (model cache volume → warm runs measure inference), plus a real DeepL en→el job and an optional YouTube leg; computes WER per model. `BENCHMARK.md` records the 2026-07-16 baseline. CLAUDE.md documents the benchmark command.

## How it was verified
Ran it (twice — cold and warm):
```
tiny 30s/5s, base 30s/5s, small 96s/10s, medium 298s/26s — all WER 7% (= only the invented word 'Txtify' wrong)
large: OOM at 7.7GB Docker RAM (documented; needs ~10GB)
deepl en→el: 'Η γρήγορη καφέ αλεπού πηδάει πάνω από τον τεμπέλη σκύλο.' (10s)
youtube: transcribed 19s video in 8s
```