### PR TITLE
ci: run the Docker E2E gate on worker-path pull requests

### DIFF
--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -1,0 +1,26 @@
+name: Docker E2E
+
+on:
+  pull_request:
+    paths:
+      - "requirements.txt"
+      - "Dockerfile"
+      - ".dockerignore"
+      - "docker-compose.yml"
+      - "src/**"
+      - "scripts/docker_e2e.sh"
+      - "tests/fixtures/**"
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run end-to-end gate (build, boot, real transcription, exports)
+        run: ./scripts/docker_e2e.sh
+        env:
+          # no DEEPL key in CI: the transcription leg is the gate; translation
+          # is covered by scripts/benchmark.sh locally
+          DEEPL_API_KEY: ""


### PR DESCRIPTION
## Problem
The unit suite stubs the ML stack, so a PR breaking the subprocess spawn, worker argv contract, or the image itself merges green (this class of bug happened twice this week: torchaudio mismatch, argv drift).

## Change
New `Docker E2E` workflow runs `scripts/docker_e2e.sh` (build → boot → real whisper-tiny transcription → export assertions) on PRs touching requirements, Dockerfile, src/, or the script; manual dispatch supported. Path-filtered so docs PRs don't pay the ~15 min.

## How it was verified
yaml validated; the same script passes locally on the integration tree (`PASS: docker E2E complete`). This PR itself triggers the workflow — its own green check is the proof.