### PR TITLE
docs: keep agent guide scoped to this repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ demo txtify.mp4
 old_files/
 # Committed test fixture is an explicit exception to the media ban
 !tests/fixtures/speech.mp3
+
+# Local-only agent notes
+CLAUDE.local.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Txtify — agent guide
 
-FastAPI web app that transcribes/translates audio & video: YouTube URL or upload → Whisper via stable-ts → optional DeepL translation → export as txt/srt/vtt/sbv/pdf. Single Docker container on port 8011, Jinja2 templates + vanilla JS frontend, SQLite for job state. Live at txtify.lkmeta.com (deployed from Docker Hub `lkmeta/txtify`). The public marketing site lives in the separate `lkmeta/txtify-web` repo — never edit site content here.
+FastAPI web app that transcribes/translates audio & video: YouTube URL or upload → Whisper via stable-ts → optional DeepL translation → export as txt/srt/vtt/sbv/pdf. Single Docker container on port 8011, Jinja2 templates + vanilla JS frontend, SQLite for job state. Deployed from Docker Hub `lkmeta/txtify`.
 
 ## Architecture (read this before touching job flow)
 
@@ -35,14 +35,6 @@ For quick local work you don't need the ML stack: install `requirements-dev.txt`
 - `transformers`, `accelerate`, `srt`, `webvtt-py` were removed as unused — don't re-add without an actual import.
 - Product name is **Txtify**, never "Textify".
 - Worker failures are invisible in the server log (stdout/stderr piped and unread). Debug via `output/<job id>_logs.txt`, or run `python src/transcribe_process.py <job_id> <file> en whisper_tiny none en all` manually.
-
-## Sibling repo: txtify-web (the public site)
-
-- Located at `../txtify-web` (github.com/lkmeta/txtify-web), deployed on Vercel at txtify.lkmeta.com. It is the **marketing/demo site only**: its transcription flow is fake (demo mode), its contact form emails the owner via Resend. This repo (`txtify`) is the real engine that self-hosters run via Docker.
-- **Division of labor:** engine features, job flow, models, Docker → here. Site copy, SEO, accessibility, site performance, contact form → txtify-web. Don't fix site content here or engine behavior there.
-- **Limits sync contract:** user-facing limits are stated in BOTH repos. Here: `MAX_UPLOAD_SIZE_MB` / `MAX_VIDEO_DURATION` in `src/utils.py` (+ this repo's own templates). In txtify-web: `MAX_FILE_SIZE` / `MAX_YOUTUBE_DURATION` in `src/main.py` (Jinja globals — its single source). If you change limits here, update txtify-web's `src/main.py` too (both currently state 1000MB / 15 minutes — in sync as of July 2026).
-- The site also states: model list (Whisper Tiny→Large, all multilingual), 72 transcription / 34 translation languages (computed from its JSONs), export formats txt/srt/vtt/sbv/pdf. If any of those change here, tell txtify-web (its language JSONs are copies of this repo's).
-- txtify-web has its own CLAUDE.md, smoke-test CI, and a `ui-review` skill — reuse them there rather than rebuilding.
 
 ## Conventions
 


### PR DESCRIPTION
Trims CLAUDE.md to facts about this repo only and gitignores CLAUDE.local.md for local-only notes.