### PR TITLE
feat: configurable limits + visible worker failures

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,9 @@ RUNNING_LOCALLY=True
 # -------------------
 # Max transcriptions running at once (each is a full Whisper process).
 MAX_CONCURRENT_JOBS=2
+
+# -------------------
+# Upload/duration limits (defaults shown). Raise or lower per deployment;
+# longer media needs proportionally more time, disk, and memory.
+MAX_UPLOAD_SIZE_MB=1000
+MAX_VIDEO_DURATION=900

--- a/src/main.py
+++ b/src/main.py
@@ -340,10 +340,16 @@ async def status(pid: Optional[int] = None):
         )
         if worker_pid and not already_terminal and not is_worker_alive(worker_pid):
             logger.error(f"Worker for job {pid} died without finishing")
-            DB.update_transcription_status("Error", str(time.time()), 0, pid)
+            died_msg = (
+                "Error: the transcription worker stopped unexpectedly. "
+                "This is usually the machine running out of memory for the "
+                "selected model — try a smaller model (e.g. base). "
+                f"Details in output/{pid}_logs.txt."
+            )
+            DB.update_transcription_status(died_msg, str(time.time()), 0, pid)
             return {
                 "progress": "0",
-                "phase": "Error",
+                "phase": died_msg,
                 "model": status_data["model"],
                 "language": status_data["language"],
                 "translation": status_data["translation"],

--- a/src/utils.py
+++ b/src/utils.py
@@ -5,6 +5,7 @@ PDF, SRT, VTT, and SBV. It also includes helper functions for cleaning filenames
 validating YouTube URLs, and managing file cleanup.
 """
 
+import os
 import re
 import shutil
 import subprocess
@@ -24,10 +25,10 @@ OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
 DB = transcriptionsDB(OUTPUT_DIR / "transcriptions.db")
 
-# User-facing limits. Keep the copy in templates/index.html and
-# templates/faq.html in sync when changing these.
-MAX_VIDEO_DURATION = 15 * 60  # YouTube audio is truncated at 15 minutes
-MAX_UPLOAD_SIZE_MB = 1000  # uploaded files are rejected above 1000 MB
+# User-facing limits, overridable per deployment. Keep the copy in
+# templates/index.html and templates/faq.html in sync when changing defaults.
+MAX_VIDEO_DURATION = int(os.getenv("MAX_VIDEO_DURATION", 15 * 60))  # seconds; longer videos are rejected
+MAX_UPLOAD_SIZE_MB = int(os.getenv("MAX_UPLOAD_SIZE_MB", 1000))  # uploads above this are rejected
 
 
 def is_valid_youtube_url(url: str) -> bool:

--- a/static/scripts.js
+++ b/static/scripts.js
@@ -224,10 +224,14 @@ function startStatusCheck(pid) {
 
                 if (response.phase.includes('Error') || response.phase === 'Canceled') {
                     clearInterval(transcriptionInterval);
+                    // Show the server's actual error (it carries the cause and
+                    // a hardware hint) instead of a generic failure line.
                     document.getElementById('progressPhase').innerText =
                         response.phase === 'Canceled'
                             ? 'Transcription canceled.'
-                            : 'Transcription failed. Check the job logs or try again.';
+                            : (response.phase.startsWith('Error:')
+                                ? response.phase
+                                : 'Transcription failed. Check the job logs or try again.');
                     document.querySelector('.cancel-button').classList.add('hidden');
                     document.querySelector('.close-button').classList.remove('hidden');
                     document.querySelector('.spinner').style.display = 'none';

--- a/templates/faq.html
+++ b/templates/faq.html
@@ -169,9 +169,10 @@
 
             <h2>Limitations</h2>
             <h3>Are there any limitations?</h3>
-            <p>Yes, this version has limitations. You can upload files up to 1000MB or transcribe YouTube videos up
-                to 15 minutes. However, when you self-host Txtify, you can modify and run the application without these
-                limitations, giving you full control over the transcription process.</p>
+            <p>By default you can upload files up to 1000MB and transcribe YouTube videos up to 15 minutes. These
+                are safety defaults, not hard limits: set the <code>MAX_UPLOAD_SIZE_MB</code> and
+                <code>MAX_VIDEO_DURATION</code> (seconds) environment variables to raise or remove them for your
+                own deployment. Keep in mind that longer media needs proportionally more time, disk, and memory.</p>
 
 
             <!-- <h3>____________________________________________________________</h3> -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -67,7 +67,7 @@
             Txtify supports files up to 
             <span style="color: var(--primary-color); font-weight: bold;">1000MB</span> 
             and YouTube videos up to 
-            <span style="color: var(--primary-color); font-weight: bold;">15 minutes</span>.
+            <span style="color: var(--primary-color); font-weight: bold;">15 minutes</span> by default (both configurable via environment variables).
         </div>
 
         <div class="switch-case">
@@ -76,12 +76,12 @@
         </div>
         <div id="youtube-input" class="input-group">
             <label for="youtube-url">YouTube URL:</label>
-            <small>Enter the URL of the YouTube video you want to transcribe (max 15 minutes of transcription).</small>
+            <small>Enter the URL of the YouTube video you want to transcribe (default max 15 minutes — configurable).</small>
             <input type="text" id="youtube-url" placeholder="Enter YouTube URL">
         </div>
         <div id="upload-input" class="input-group" style="display: none;">
             <label for="media-upload">Upload Audio/Video:</label>
-            <small>Upload an audio or video file from your device to transcribe (.mp3, .mp4, .m4a, .wav, .webm and more -- max 1000MB).</small>
+            <small>Upload an audio or video file from your device to transcribe (.mp3, .mp4, .m4a, .wav, .webm and more -- default max 1000MB, configurable).</small>
             <input type="file" id="media-upload" accept=".mp3,.mp4,.m4a,.wav,.webm,.ogg,.flac,.aac,.mov">
         </div>
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -144,3 +144,21 @@ def test_kill_process_by_pid_kills_the_process_itself():
     assert proc.returncode is not None
     _time.sleep(0)
     assert utils.kill_process_by_pid(proc.pid) is False
+
+
+def test_limits_overridable_via_env(monkeypatch):
+    import importlib
+
+    monkeypatch.setenv("MAX_UPLOAD_SIZE_MB", "50")
+    monkeypatch.setenv("MAX_VIDEO_DURATION", "120")
+    import utils
+
+    importlib.reload(utils)
+    assert utils.MAX_UPLOAD_SIZE_MB == 50
+    assert utils.MAX_VIDEO_DURATION == 120
+
+    monkeypatch.delenv("MAX_UPLOAD_SIZE_MB")
+    monkeypatch.delenv("MAX_VIDEO_DURATION")
+    importlib.reload(utils)
+    assert utils.MAX_UPLOAD_SIZE_MB == 1000
+    assert utils.MAX_VIDEO_DURATION == 900


### PR DESCRIPTION
## Problem
Two of the top user-reported problems (issues #9, #10, #11): the 15-minute/1000MB limits are hardcoded, so self-hosters with long media hit them with no way out; and when the worker dies mid-job (usually out of memory on the bigger models) the UI shows a bare error or, historically, hung forever.

## Change
- `MAX_UPLOAD_SIZE_MB` and `MAX_VIDEO_DURATION` are now environment variables (defaults unchanged: 1000 MB / 900 s). Documented in `.env.example`, the FAQ, and the homepage copy.
- When `/status` detects a dead worker it now writes and returns a message with the likely cause (machine ran out of memory for the selected model, try a smaller one) and the log file path, instead of a bare "Error".
- The frontend shows that actual server message instead of a generic failure line.

## How it was verified
- `pytest`: 52 passed (new test: limits override via env and defaults restore).
- `./scripts/docker_e2e.sh`: **PASS: docker E2E complete** (full real-transcription gate, all exports, honest translation-failure status).

## Deferred
Speaker diarization, MKV input, model caching between runs (tracked for the next round).

🤖 Generated with [Claude Code](https://claude.com/claude-code)