### PR TITLE
fix: exclude Auto-Detect from homepage language count

### DIFF
--- a/static/scripts.js
+++ b/static/scripts.js
@@ -483,7 +483,10 @@ function populateLanguageDropdown() {
     // Set English as default selected language
     languageChoice.value = 'en';
 
-    document.getElementById('transcription-languages').innerText = Object.keys(languagesData).length;
+    // Auto-Detect is an option, not a language — keep the count honest
+    // (the website derives the same number and its CI checks for drift).
+    document.getElementById('transcription-languages').innerText =
+        Object.values(languagesData).filter(l => l.name !== 'Auto-Detect').length;
 }
 
 function updateLanguageCodes() {


### PR DESCRIPTION
## Problem
The homepage counts transcription languages with Object.keys over the ASR JSON, which includes the Auto-Detect entry — it showed 73 instead of 72. The website derives the same number and its CI now fails on drift.

## Change
Filter out the Auto-Detect entry before counting. The translation JSON has no auto entry, so that count was already right.

## How it was verified
python over static/supported_languages_ASR.json: 73 entries, 72 excluding Auto-Detect. pytest unaffected (frontend-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)