### PR TITLE
fix: CPU-only torch — amd64 image ~2.5GB smaller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,13 @@ COPY requirements.txt .
 # Upgrade pip
 RUN pip install --no-cache-dir --upgrade pip
 
+# CPU-only torch first: the default amd64 wheels bundle ~2.5 GB of CUDA
+# libraries this app never uses (inference is CPU-only). Same pinned
+# versions as requirements.txt — keep them identical, a torch/torchaudio
+# mismatch crashes the worker at import.
+RUN pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu \
+    torch==2.9.1 torchaudio==2.9.1
+
 # Install any dependencies specified in requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION
## Problem
The amd64 image is ~3GB compressed because plain `torch==2.9.1` resolves to CUDA wheels, bundling ~2.5GB of nvidia libraries the app never executes — inference is CPU-only. This is the same image-weight complaint from the issue #6 thread, still unfixed.

## Change
Install `torch`/`torchaudio` from the PyTorch CPU wheel index (same pinned 2.9.1 versions, keeping the torch==torchaudio invariant) before the requirements install. arm64 is unaffected (no CUDA wheels exist for it). Anyone wanting GPU can build from source with default wheels.

## How it was verified
`./scripts/docker_e2e.sh` on the new Dockerfile: **PASS: docker E2E complete** — real speech transcribed correctly, all exports present, honest translation-failure status. Identical accuracy by construction: same torch version, CPU execution paths are the same code in both wheel variants.

## Deferred
Multi-stage build to drop gcc/python3-dev from the final layer (~150MB more).

🤖 Generated with [Claude Code](https://claude.com/claude-code)