### PR TITLE
chore: add FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: lkmeta


### PR DESCRIPTION
## Problem
GitHub Sponsors profile is live but the public repo has no FUNDING.yml, so there is no Sponsor button where the traffic actually lands.

## Change
`.github/FUNDING.yml` with `github: lkmeta`.

## How it was verified
Config-only; github.com/sponsors/lkmeta returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)