### PR TITLE
feat: mkv/avi input + weekly published-image check

### DIFF
--- a/.github/workflows/published-image-check.yml
+++ b/.github/workflows/published-image-check.yml
@@ -1,0 +1,26 @@
+name: Published Image Check
+
+# Weekly gate on what users actually pull from Docker Hub: boots
+# lkmeta/txtify:latest and runs every casual scenario end-to-end
+# (health, pages, mp3 + mkv transcription with word-accuracy asserts,
+# honest translation failure, validation errors, zip/pdf export).
+# Fails loudly if a broken image ever gets published.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      image:
+        description: "Image to check"
+        default: "lkmeta/txtify:latest"
+        required: false
+
+jobs:
+  e2e-published:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run E2E against published image
+        run: IMAGE="${{ github.event.inputs.image || 'lkmeta/txtify:latest' }}" ./scripts/docker_e2e.sh

--- a/scripts/docker_e2e.sh
+++ b/scripts/docker_e2e.sh
@@ -4,17 +4,26 @@
 # polls /status until the transcription completes, and checks every export.
 #
 # Usage: ./scripts/docker_e2e.sh [port]
+#   IMAGE=lkmeta/txtify:latest ./scripts/docker_e2e.sh   # test a published
+#   image instead of building from the working tree (used by the scheduled
+#   published-image check so a broken push gets caught, not discovered).
 set -euo pipefail
 
 PORT="${1:-8077}"
-IMAGE=txtify:e2e
+IMAGE="${IMAGE:-}"
 NAME=txtify_e2e
 BASE="http://127.0.0.1:${PORT}"
 WORKDIR="$(mktemp -d)"
 trap 'docker rm -f $NAME >/dev/null 2>&1 || true; rm -rf "$WORKDIR"' EXIT
 
-echo "==> Building image"
-docker build -q -t $IMAGE .
+if [ -z "$IMAGE" ]; then
+  IMAGE=txtify:e2e
+  echo "==> Building image"
+  docker build -q -t $IMAGE .
+else
+  echo "==> Testing published image: $IMAGE"
+  docker pull -q "$IMAGE"
+fi
 
 echo "==> Starting container"
 docker run -d --rm --name $NAME -p "${PORT}:8011" $IMAGE >/dev/null
@@ -67,6 +76,26 @@ case "$LISTING" in
   *final_transcription.pdf*) ;;
   *) echo "FAIL: pdf missing from zip"; exit 1 ;;
 esac
+
+echo "==> MKV upload (video container path — converted to mp3 by ffmpeg in-app)"
+docker cp tests/fixtures/speech.mp3 "$NAME:/tmp/speech.mp3" >/dev/null
+docker exec $NAME ffmpeg -y -loglevel error -i /tmp/speech.mp3 -c:a aac /tmp/speech.mkv
+docker cp "$NAME:/tmp/speech.mkv" "$WORKDIR/speech.mkv" >/dev/null
+MKVJOB=$(curl -sf -X POST "$BASE/transcribe" \
+  -F media=@"$WORKDIR/speech.mkv" -F language=en -F model=whisper_tiny \
+  -F translation=none -F language_translation=en | python3 -c 'import json,sys; print(json.load(sys.stdin)["pid"])')
+for _ in $(seq 1 60); do
+  P=$(curl -sf "$BASE/status?pid=$MKVJOB" | python3 -c 'import json,sys; print(json.load(sys.stdin)["progress"])')
+  [ "$P" = "100" ] && break
+  [ "$P" = "0" ] && { echo "FAIL: mkv job errored"; exit 1; }
+  sleep 5
+done
+[ "$P" = "100" ] || { echo "FAIL: mkv timed out"; exit 1; }
+curl -sf "$BASE/preview?pid=$MKVJOB" | python3 -c '
+import json, sys
+assert "quick brown fox" in json.load(sys.stdin)["txt"].lower(), "mkv transcription wrong"
+print("    mkv transcribed correctly")
+'
 
 echo "==> Translation path (no DeepL key in this container -> honest failure status)"
 TJOB=$(curl -sf -X POST "$BASE/transcribe" \

--- a/src/utils.py
+++ b/src/utils.py
@@ -63,7 +63,7 @@ def is_valid_media_file(filename: str) -> bool:
     """
     # Anything ffmpeg can decode; keep in sync with the accept list
     # in templates/index.html.
-    valid_extensions = ["mp3", "mp4", "m4a", "wav", "webm", "ogg", "flac", "aac", "mov"]
+    valid_extensions = ["mp3", "mp4", "m4a", "wav", "webm", "ogg", "flac", "aac", "mov", "mkv", "avi"]
     return filename.split(".")[-1].lower() in valid_extensions
 
 

--- a/static/scripts.js
+++ b/static/scripts.js
@@ -155,7 +155,7 @@ function transcribe() {
 
     // Validate file upload
     if (mediaUpload && !isValidMediaFile(mediaUpload)) {
-        showAlert('Invalid File', 'Please upload a supported media file (.mp3, .mp4, .m4a, .wav, .webm, .ogg, .flac, .aac, .mov).');
+        showAlert('Invalid File', 'Please upload a supported media file (.mp3, .mp4, .m4a, .wav, .webm, .ogg, .flac, .aac, .mov, .mkv, .avi).');
         return;
     }
 
@@ -269,7 +269,7 @@ function isValidYoutubeUrl(url) {
 
 function isValidMediaFile(file) {
     // Keep in sync with valid_extensions in src/utils.py
-    const validExtensions = ['mp3', 'mp4', 'm4a', 'wav', 'webm', 'ogg', 'flac', 'aac', 'mov'];
+    const validExtensions = ['mp3', 'mp4', 'm4a', 'wav', 'webm', 'ogg', 'flac', 'aac', 'mov', 'mkv', 'avi'];
     const fileExtension = file.name.split('.').pop().toLowerCase();
     return validExtensions.includes(fileExtension);
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -82,7 +82,7 @@
         <div id="upload-input" class="input-group" style="display: none;">
             <label for="media-upload">Upload Audio/Video:</label>
             <small>Upload an audio or video file from your device to transcribe (.mp3, .mp4, .m4a, .wav, .webm and more -- default max 1000MB, configurable).</small>
-            <input type="file" id="media-upload" accept=".mp3,.mp4,.m4a,.wav,.webm,.ogg,.flac,.aac,.mov">
+            <input type="file" id="media-upload" accept=".mp3,.mp4,.m4a,.wav,.webm,.ogg,.flac,.aac,.mov,.mkv,.avi">
         </div>
 
         <div class="input-group">

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,6 +27,8 @@ def test_clean_filename():
         ("a.m4a", True),
         ("a.wav", True),
         ("a.webm", True),
+        ("a.mkv", True),
+        ("a.AVI", True),
         ("a.exe", False),
         ("a.txt", False),
     ],


### PR DESCRIPTION
## Problem
Users transcribe TV episodes and screen recordings (M0 item; issue #11 was an mkv-era pipeline); mkv/avi were rejected at validation despite ffmpeg handling them fine. And nothing watches the published Docker Hub image — a broken push would be discovered by a stranger's issue.

## Change
- `mkv` + `avi` accepted end-to-end (utils validation, JS list + alert, accept attribute, tests).
- `docker_e2e.sh`: new MKV scenario with word-accuracy assert; `IMAGE=` env to run the suite against a published image without building.
- New `published-image-check.yml`: Mondays 06:00 UTC + manual dispatch, runs the full E2E suite against `lkmeta/txtify:latest` on amd64 runners — exactly what self-hosters pull.

## How it was verified
- pytest: 54 passed (new mkv/AVI validation cases).
- `./scripts/docker_e2e.sh`: **PASS: docker E2E complete**, including the new scenario — "mkv transcribed correctly" (real conversion + transcription, not just validation).

## Deferred
Benchmark table, model caching, diarization (M0 tail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)